### PR TITLE
add missing descriptions for Dol Amroth class skills for EN, DE, and FR

### DIFF
--- a/src/IndexedDictionaryDe.lua
+++ b/src/IndexedDictionaryDe.lua
@@ -138,7 +138,8 @@ function TravelDictionaries:CreateDictionaries()
     hunterLocations:AddSkill("Führer nach Forlach", "0x70036B5D", "Forlach (Führer)");
     hunterLocations:AddSkill("Führer nach Aldburg", "0x7003DC71", "Aldburg (Führer)");
     hunterLocations:AddSkill("Führer nach Helms Klamm", "0x7003DC72", "Helms Klamm (Führer)");
-    hunterLocations:AddSkill("Führer nach Dol Amroth", "0x70041197", "Dol Amroth (Führer)");
+    hunterLocations:AddSkill("Führer nach Dol Amroth", "0x70041197", "Dol Amroth (Führer)",
+                             "nach Dol Amroth.");
     hunterLocations:AddSkill("Führer nach Arnach", "0x70043A63", "Arnach (Führer)");
     hunterLocations:AddSkill("Führer nach Minas Tirith", "0x70044985", "Minas Tirith (Führer)");
     hunterLocations:AddSkill("Führer zum Kriegslager der Rohirrim", "0x700459AF", "Kriegslager der Rohirrim (Führer)");
@@ -170,7 +171,8 @@ function TravelDictionaries:CreateDictionaries()
     hunterLocations:AddSkill("Führer nach Carn Dûm", "0x70064AC8", "Carn Dûm (Führer)");
     hunterLocations:AddSkill("Führer nach Clegur", "0x70064F4C", "Clegur (Führer)");
     hunterLocations:AddSkill("Führer nach Pelargir", "0x700658EA", "Pelargir (Führer)");
-    hunterLocations:AddSkill("Führer nach Dol Amroth", "0x70068711", "Dol Amroth (Führer U38)");
+    hunterLocations:AddSkill("Führer nach Dol Amroth", "0x70068711", "Königreich Dol Amroth (Führer U38)",
+                             "Königreich Gondor");
     hunterLocations:AddSkill("Führer nach Halrax", "0x70068713", "Halrax (Führer)");
     hunterLocations:AddSkill("Führer nach Lond Cirion", "0x70068717", "Lond Cirion (Führer)");
     hunterLocations:AddSkill("Führer nach Umbar", "0x70068718", "Umbar (Führer)");
@@ -194,7 +196,8 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Appell in Forlach", "0x70036B5B", "Forlach (Appell)");
     wardenLocations:AddSkill("Appell in Aldburg", "0x7003DC7A", "Aldburg (Appell)");
     wardenLocations:AddSkill("Appell in Helms Klamm", "0x7003DC79", "Helms Klamm (Appell)");
-    wardenLocations:AddSkill("Appell in Dol Amroth", "0x70041198", "Dol Amroth (Appell)");
+    wardenLocations:AddSkill("Appell in Dol Amroth", "0x70041198", "Dol Amroth (Appell)",
+                             "West-Gondor zu reisen");
     wardenLocations:AddSkill("Appell in Arnach", "0x70043A66", "Arnach (Appell)");
     wardenLocations:AddSkill("Appell in Minas Tirith", "0x70044982", "Minas Tirith (Appell)");
     wardenLocations:AddSkill("Appell im Kriegslager", "0x700459AA", "Kriegslager der Rohirrim (Appell)");
@@ -229,7 +232,8 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Appell in Jax Phanâl","0x7006870C", "Jax Phanâl (Appell)");
     wardenLocations:AddSkill("Appell in Umbar","0x7006870F","Umbar (Appell)");
     wardenLocations:AddSkill("Appell in Halrax","0x70068710", "Halrax (Appell)");
-    wardenLocations:AddSkill("Appell in Dol Amroth","0x70068712", "Dol Amroth (Appell)");
+    wardenLocations:AddSkill("Appell in Dol Amroth","0x70068712", "Königreich Dol Amroth (Appell)",
+                             "Königreich Gondor");
     wardenLocations:AddSkill("Appell in Lond Cirion","0x70068715", "Lond Cirion (Appell)");
     wardenLocations:AddSkill("Appell in der Taverne 'Zum Blutigen Adler'","0x700697F3", "Zum Blutigen Adler (Appell)");
 
@@ -241,7 +245,8 @@ function TravelDictionaries:CreateDictionaries()
     marinerLocations:AddSkill("Segelt nach Seestadt.", "0x7006610C", "Seestadt (Segeln)")
     marinerLocations:AddSkill("Segelt zur Dunkelsenke", "0x7006610E", "Dunkelsenke (Segeln)")
     marinerLocations:AddSkill("Segelt nach Tinnudir", "0x7006610F", "Tinnundir (Segeln)")
-    marinerLocations:AddSkill("Segelt nach Dol Amroth", "0x70066117", "Dol Amroth (Segeln)")
+    marinerLocations:AddSkill("Segelt nach Dol Amroth", "0x70066117", "Dol Amroth (Segeln)",
+                              "nach Dol Amroth.")
     marinerLocations:AddSkill("Segelt nach Bockland", "0x7006611A", "Bockland (Segeln)")
     marinerLocations:AddSkill("Segelt nach Pelargir", "0x7006611B", "Pelargir (Segeln)")
     marinerLocations:AddSkill("Segelt nach Sûri-kylä", "0x7006611C", "Sûri-kylä (Segeln)")
@@ -251,13 +256,17 @@ function TravelDictionaries:CreateDictionaries()
     marinerLocations:AddSkill("Nach Umbar segeln", "0x700687BB", "Umbar (Segeln)")
     marinerLocations:AddSkill("Nach Lond Cirion segeln", "0x700687BD", "Lond Cirion (Segeln)")
     marinerLocations:AddSkill("Nach Jax Phanâl segeln", "0x700687C0", "Jax Phanâl (Segeln)")
-    marinerLocations:AddSkill("Segelt nach Dol Amroth", "0x700687C1", "Dol Amroth (Segeln)")
+    marinerLocations:AddSkill("Segelt nach Dol Amroth", "0x700687C1", "Königreich Dol Amroth (Segeln)",
+                              "Königreich Gondor")
     marinerLocations:AddSkill("Nach Halrax segeln", "0x700687C3", "Halrax (Segeln)")
 
-    racialLocations:AddSkill("Rückkehr nach Bree", "0x700062F6", "Bree (Rasse)");
+    racialLocations:AddSkill("Rückkehr nach Bree", "0x700062F6", "Bree (Rasse)",
+                             "Ihr könnt schnell nach Bree");
     racialLocations:AddSkill("Rückkehr ins Auenland", "0x700062C8", "Michelbinge (Rasse)");
-    racialLocations:AddSkill("Rückkehr zu Thorins Tor", "0x70006346", "Thorins Tor (Rasse Zwerg)");
-    racialLocations:AddSkill("Rückkehr nach Bruchtal", "0x7000631F", "Bruchtal (Rasse)");
+    racialLocations:AddSkill("Rückkehr zu Thorins Tor", "0x70006346", "Thorins Tor (Rasse Zwerg)",
+                             "Hiermit gelangt Ihr schnell");
+    racialLocations:AddSkill("Rückkehr nach Bruchtal", "0x7000631F", "Bruchtal (Rasse)",
+                             "Hiermit gelangt Ihr schnell");
     racialLocations:AddSkill("Zum 1. Heim zurückkehren", "0x70041A22", "Grimbeorns Hütte (Rasse)");
     racialLocations:AddSkill("Reise nach Caras Galadhon in Lothlórien", "0x70048C8C", "Caras Galadhon (Rasse)");
     racialLocations:AddSkill("Reise zu Thorins Halle", "0x70053C0F", "Thorins Halle (Rasse Starkaxt)");
@@ -279,11 +288,14 @@ function TravelDictionaries:CreateDictionaries()
     genLocations:AddSkill("Reist zum Haus Eurer Sippe", "0x7000D047", "Heim Eurer Sippe");
     genLocations:AddSkill("Zum Haus des Sippenmitglieds reisen", "0x70057C36", "Heim des Sippenmitglieds");
 
-    repLocations:AddSkill("Rückkehr zu Thorins Tor", "0x7001BF91", "Thorins Tor (Ruf)");
-    repLocations:AddSkill("Rückkehr nach Bree", "0x7001BF90", "Bree (Ruf)");
+    repLocations:AddSkill("Rückkehr zu Thorins Tor", "0x7001BF91", "Thorins Tor (Ruf)",
+                          "Dank Eurer Freundschaft");
+    repLocations:AddSkill("Rückkehr nach Bree", "0x7001BF90", "Bree (Ruf)",
+                          "Dank Eurer Freundschaft");
     repLocations:AddSkill("Kehrt zu Lalias Markt zurück", "0x700364B1", "Lalias Markt (Mithril)");
     repLocations:AddSkill("Rückkehr nach Michelbinge", "0x70023262", "Michelbinge (Shop)");
-    repLocations:AddSkill("Rückkehr nach Bruchtal", "0x70023263", "Bruchtal (Shop)");
+    repLocations:AddSkill("Rückkehr nach Bruchtal", "0x70023263", "Bruchtal (Shop)",
+                          "Dank Eurer Freundschaft");
     repLocations:AddSkill("Rückkehr zur Feste Guruth", "0x70020441", "Feste Guruth (Ruf)");
     repLocations:AddSkill("Rückkehr zum Düsterwald", "0x7001F374", "Düsterwald (Ruf)");
     repLocations:AddSkill("Rückkehr nach Enedwaith", "0x70021FA2", "Enedwaith (Ruf)");
@@ -294,7 +306,8 @@ function TravelDictionaries:CreateDictionaries()
     repLocations:AddSkill("Kehrt nach Aldburg zurück", "0x7003DC81", "Aldburg (Ruf)");
     repLocations:AddSkill("Rückkehr ins Geheimnistal", "0x7004128F", "Geheimnistal (Ruf)");
     repLocations:AddSkill("Kehrt nach Helms Klamm zurück", "0x7003DC82", "Helms Klamm (Ruf)");
-    repLocations:AddSkill("Rückkehr nach Dol Amroth", "0x700411AC", "Dol Amroth (Ruf)");
+    repLocations:AddSkill("Rückkehr nach Dol Amroth", "0x700411AC", "Dol Amroth (Ruf)",
+                          "West-Gondor zurückkehren");
     repLocations:AddSkill("Rückkehr nach Arnach", "0x70043A6A", "Arnach (Ruf)");
     repLocations:AddSkill("Kehrt nach Minas Tirith zurück.", "0x7004497E", "Minas Tirith (Ruf)");
     repLocations:AddSkill("Zurück zum Kriegslager der Rohirrim", "0x700459A9", "Kriegslager der Rohirrim (Ruf)");
@@ -335,7 +348,8 @@ function TravelDictionaries:CreateDictionaries()
     repLocations:AddSkill("Rückkehr nach Pelargir", "0x700658EB", "Pelargir (Ruf)");
     repLocations:AddSkill("Zum Orden des Adlers reisen", "0x700686FE", "Orden des Adlers (Ruf)");
     repLocations:AddSkill("Nach Umbar zurückkehren", "0x700686FF", "Umbar (Ruf)");
-    repLocations:AddSkill("Rückkehr nach Dol Amroth", "0x70068700", "Dol Amroth (Ruf U38)");
+    repLocations:AddSkill("Rückkehr nach Dol Amroth", "0x70068700", "Königreich Dol Amroth (Ruf U38)",
+                          "Königreich Gondor");
     repLocations:AddSkill("Nach Jax Phanâl zurückkehren", "0x70068701", "Jax Phanâl (Ruf)");
     repLocations:AddSkill("Kehrt zu Halrax zurück.", "0x70068702", "Halrax (Ruf)");
     repLocations:AddSkill("Nach Lond Cirion zurückkehren", "0x70068703", "Lond Cirion (Ruf)");

--- a/src/IndexedDictionaryDe.lua
+++ b/src/IndexedDictionaryDe.lua
@@ -207,7 +207,7 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Appell im Lager des Heeres", "0x70047BFC", "Lager des Heeres (Appell)");
     wardenLocations:AddSkill("Appell in Haerondir", "0x70047C23", "Haerondir (Appell)");
     wardenLocations:AddSkill("Appell am Udûn-Brückenkopf", "0x7004AE1F", "Udûn-Brückenkopf (Appell)");
-    wardenLocations:AddSkill("Appell in Thal", "0x7004d73a", "Thal (Appell)");
+    wardenLocations:AddSkill("Appell in Thal", "0x7004d73A", "Thal (Appell)");
     wardenLocations:AddSkill("Appell in Járnfast", "0x7004FACA", "Jarnfast (Appell)");
     wardenLocations:AddSkill("Appell in Skarháld", "0x7004FACD",  "Skarhald (Appell)");
     wardenLocations:AddSkill("Appell im Beorningerhús", "0x70052F0A", "Beorningerhús (Appell)");

--- a/src/IndexedDictionaryDe.lua
+++ b/src/IndexedDictionaryDe.lua
@@ -177,7 +177,7 @@ function TravelDictionaries:CreateDictionaries()
     hunterLocations:AddSkill("Führer nach Lond Cirion", "0x70068717", "Lond Cirion (Führer)");
     hunterLocations:AddSkill("Führer nach Umbar", "0x70068718", "Umbar (Führer)");
     hunterLocations:AddSkill("Führer nach Jax Phanâl", "0x70068719", "Jax Phanâl (Führer)");
-    hunterLocations:AddSkill("Führer zur Taverne 'Zum Blutigen Adler'", "0x700697EF", "Zum Blutigen Adler (Führer)");
+    hunterLocations:AddSkill("Führer zur Taverne \"Zum Blutigen Adler\"", "0x700697EF", "Zum Blutigen Adler (Führer)");
 
     -- add the Warden locations
     wardenLocations:AddSkill("Appell in der Feste Guruth", "0x70014786", "Feste Guruth (Appell)");
@@ -235,7 +235,7 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Appell in Dol Amroth","0x70068712", "Königreich Dol Amroth (Appell)",
                              "Königreich Gondor");
     wardenLocations:AddSkill("Appell in Lond Cirion","0x70068715", "Lond Cirion (Appell)");
-    wardenLocations:AddSkill("Appell in der Taverne 'Zum Blutigen Adler'","0x700697F3", "Zum Blutigen Adler (Appell)");
+    wardenLocations:AddSkill("Appell in der Taverne \"Zum Blutigen Adler\"","0x700697F3", "Zum Blutigen Adler (Appell)");
 
     -- add the Mariner locations
     marinerLocations:AddSkill("Segelt nach Celondim", "0x70066100", "Celondim (Segeln)")
@@ -354,7 +354,7 @@ function TravelDictionaries:CreateDictionaries()
     repLocations:AddSkill("Kehrt zu Halrax zurück.", "0x70068702", "Halrax (Ruf)");
     repLocations:AddSkill("Nach Lond Cirion zurückkehren", "0x70068703", "Lond Cirion (Ruf)");
     repLocations:AddSkill("Zu den Buchhütern reisen", "0x70068704", "Ledger-Keepers (Ruf)");
-    repLocations:AddSkill("Rückkehr zur Taverne 'Zum Blutigen Adler'", "0x700697F2", "Zum Blutigen Adler (Ruf)");
+    repLocations:AddSkill("Rückkehr zur Taverne \"Zum Blutigen Adler\"", "0x700697F2", "Zum Blutigen Adler (Ruf)");
 
     -- monster player maps
     creepLocations:AddSkill("Kartenskizze zum Gramfuss", "0x70028BBC");

--- a/src/IndexedDictionaryEn.lua
+++ b/src/IndexedDictionaryEn.lua
@@ -138,7 +138,8 @@ function TravelDictionaries:CreateDictionaries()
     hunterLocations:AddSkill("Guide to Forlaw", "0x70036B5D", "Forlaw (Guide)");
     hunterLocations:AddSkill("Guide to Aldburg", "0x7003DC71", "Aldburg (Guide)");
     hunterLocations:AddSkill("Guide to Helm's Deep", "0x7003DC72", "Helm's Deep (Guide)");
-    hunterLocations:AddSkill("Guide to Dol Amroth", "0x70041197", "Dol Amroth (Guide)"); -- TODO: add desc
+    hunterLocations:AddSkill("Guide to Dol Amroth", "0x70041197", "Dol Amroth (Guide)",
+                             "Dol Amroth in western Gondor");
     hunterLocations:AddSkill("Guide to Arnach", "0x70043A63", "Arnach (Guide)");
     hunterLocations:AddSkill("Guide to Minas Tirith", "0x70044985", "Minas Tirith (Guide)");
     hunterLocations:AddSkill("Guide to the War-stead", "0x700459AF", "War-stead (Guide)");
@@ -170,7 +171,8 @@ function TravelDictionaries:CreateDictionaries()
     hunterLocations:AddSkill("Guide to Carn Dûm", "0x70064AC8", "Carn Dûm (Guide)");
     hunterLocations:AddSkill("Guide to Clegur", "0x70064F4C", "Clegur (Guide)");
     hunterLocations:AddSkill("Guide to Pelargir", "0x700658EA", "Pelargir (Guide)");
-    hunterLocations:AddSkill("Guide to Dol Amroth", "0x70068711", "King's Dol Amroth (Guide U38)"); -- TODO: add desc
+    hunterLocations:AddSkill("Guide to Dol Amroth", "0x70068711", "King's Dol Amroth (Guide U38)",
+                             "King's Gondor");
     hunterLocations:AddSkill("Guide to Halrax", "0x70068713", "Halrax (Guide)");
     hunterLocations:AddSkill("Guide to Lond Cirion", "0x70068717", "Lond Cirion (Guide)");
     hunterLocations:AddSkill("Guide to Umbar", "0x70068718", "Umbar (Guide)");
@@ -194,7 +196,8 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Muster in Forlaw", "0x70036B5B", "Forlaw (Muster)");
     wardenLocations:AddSkill("Muster in Aldburg", "0x7003DC7A", "Aldburg (Muster)");
     wardenLocations:AddSkill("Muster in Helm's Deep", "0x7003DC79", "Helm's Deep (Muster)");
-    wardenLocations:AddSkill("Muster in Dol Amroth", "0x70041198", "Dol Amroth (Muster)");  -- TODO: add desc
+    wardenLocations:AddSkill("Muster in Dol Amroth", "0x70041198", "Dol Amroth (Muster)",
+                             "Dol Amroth in western Gondor");
     wardenLocations:AddSkill("Muster in Arnach", "0x70043A66", "Arnach (Muster)");
     wardenLocations:AddSkill("Muster in Minas Tirith", "0x70044982", "Minas Tirith (Muster)");
     wardenLocations:AddSkill("Muster in the War-stead", "0x700459AA", "War-stead (Muster)");
@@ -229,7 +232,8 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Muster at Jax Phanâl","0x7006870C", "Jax Phanâl (Muster)");
     wardenLocations:AddSkill("Muster at Umbar","0x7006870F","Umbar (Muster)");
     wardenLocations:AddSkill("Muster at Halrax","0x70068710", "Halrax (Muster)");
-    wardenLocations:AddSkill("Muster at Dol Amroth","0x70068712", "King's Dol Amroth (Muster)"); -- TODO: add desc
+    wardenLocations:AddSkill("Muster at Dol Amroth","0x70068712", "King's Dol Amroth (Muster)",
+                             "King's Gondor");
     wardenLocations:AddSkill("Muster at Lond Cirion","0x70068715", "Lond Cirion (Muster)");
     wardenLocations:AddSkill("Muster at the Bloody Eagle Tavern","0x700697F3", "Bloody Eagle Tavern (Muster)");
 
@@ -241,7 +245,8 @@ function TravelDictionaries:CreateDictionaries()
     marinerLocations:AddSkill("Sail to Lake-town", "0x7006610C", "Lake-town (Sail)")
     marinerLocations:AddSkill("Sail to the Mirk-eaves", "0x7006610E", "Mirk-eaves (Sail)")
     marinerLocations:AddSkill("Sail to Tinnudir", "0x7006610F", "Tinnudir (Sail)")
-    marinerLocations:AddSkill("Sail to Dol Amroth", "0x70066117", "Dol Amroth (Sail)") -- TODO: add desc arg
+    marinerLocations:AddSkill("Sail to Dol Amroth", "0x70066117", "Dol Amroth (Sail)",
+                              "Dol Amroth with nearby")
     marinerLocations:AddSkill("Sail to Buckland", "0x7006611A", "Buckland (Sail)")
     marinerLocations:AddSkill("Sail to Pelargir", "0x7006611B", "Pelargir (Sail)")
     marinerLocations:AddSkill("Sail to Sûri-kylä", "0x7006611C", "Sûri-kylä (Sail)")
@@ -251,7 +256,8 @@ function TravelDictionaries:CreateDictionaries()
     marinerLocations:AddSkill("Sail to Umbar", "0x700687BB", "Umbar (Sail)")
     marinerLocations:AddSkill("Sail to Lond Cirion", "0x700687BD", "Lond Cirion (Sail)")
     marinerLocations:AddSkill("Sail to Jax Phanâl", "0x700687C0", "Jax Phanâl (Sail)")
-    marinerLocations:AddSkill("Sail to Dol Amroth", "0x700687C1", "King's Dol Amroth (Sail)")  -- TODO: add desc arg
+    marinerLocations:AddSkill("Sail to Dol Amroth", "0x700687C1", "King's Dol Amroth (Sail)",
+                              "King's Gondor")
     marinerLocations:AddSkill("Sail to Halrax", "0x700687C3", "Halrax (Sail)")
 
     -- add the racial travel skills
@@ -304,7 +310,7 @@ function TravelDictionaries:CreateDictionaries()
     repLocations:AddSkill("Return to Derndingle", "0x7004128F", "Derndingle (Rep)");
     repLocations:AddSkill("Return to Helm's Deep", "0x7003DC82", "Helm's Deep (Rep)");
     repLocations:AddSkill("Return to Dol Amroth", "0x700411AC", "Dol Amroth (Rep)",
-                          "quickly return to Dol Amroth in western Gondor");
+                          "Dol Amroth in western Gondor");
     repLocations:AddSkill("Return to Arnach", "0x70043A6A", "Arnach (Rep)");
     repLocations:AddSkill("Return to Minas Tirith", "0x7004497E", "Minas Tirith (Rep)");
     repLocations:AddSkill("Return to the War-stead", "0x700459A9", "War-stead (Rep)");
@@ -345,7 +351,8 @@ function TravelDictionaries:CreateDictionaries()
     repLocations:AddSkill("Return to Pelargir", "0x700658EB", "Pelargir (Rep)");
     repLocations:AddSkill("Journey to the Order of the Eagle", "0x700686FE", "Order of the Eagle (Rep)");
     repLocations:AddSkill("Return to Umbar", "0x700686FF", "Umbar (Rep)");
-    repLocations:AddSkill("Return to Dol Amroth", "0x70068700", "King's Dol Amroth (Rep U38)", "King's Gondor");
+    repLocations:AddSkill("Return to Dol Amroth", "0x70068700", "King's Dol Amroth (Rep U38)",
+                          "King's Gondor");
     repLocations:AddSkill("Return to Jax Phanâl", "0x70068701", "Jax Phanâl (Rep)");
     repLocations:AddSkill("Return to Halrax", "0x70068702", "Halrax (Rep)");
     repLocations:AddSkill("Return to Lond Cirion", "0x70068703", "Lond Cirion (Rep)");

--- a/src/IndexedDictionaryFr.lua
+++ b/src/IndexedDictionaryFr.lua
@@ -137,7 +137,8 @@ function TravelDictionaries:CreateDictionaries()
     hunterLocations:AddSkill("Guide vers Forloi", "0x70036B5D", "Forloi (Guide)");
     hunterLocations:AddSkill("Guide vers Aldburg", "0x7003DC71", "Aldburg (Guide)");
     hunterLocations:AddSkill("Guide vers le Gouffre de Helm", "0x7003DC72", "Gouffre de Helm (Guide)");
-    hunterLocations:AddSkill("Guide vers Dol Amroth", "0x70041197", "Dol Amroth (Guide)");
+    hunterLocations:AddSkill("Guide vers Dol Amroth", "0x70041197", "Dol Amroth (Guide)",
+                             "l'Ouest du Gondor");
     hunterLocations:AddSkill("Guide pour Arnach", "0x70043A63", "Arnach (Guide)");
     hunterLocations:AddSkill("Guide vers Minas Tirith", "0x70044985", "Minas Tirith (Guide)");
     hunterLocations:AddSkill("Guide pour se rendre au camp militaire", "0x700459AF", "Camp militaire (Guide)");
@@ -169,7 +170,8 @@ function TravelDictionaries:CreateDictionaries()
     hunterLocations:AddSkill("Guide vers Carn Dûm", "0x70064AC8", "Carn Dûm (Guide)");
     hunterLocations:AddSkill("Guide vers Clegur", "0x70064F4C", "Clegur (Guide)");
     hunterLocations:AddSkill("Guide vers Pelargir", "0x700658EA", "Pelargir (Guide)");
-    hunterLocations:AddSkill("Guide vers Dol Amroth", "0x70068711", "Dol Amroth (Guide U38)");
+    hunterLocations:AddSkill("Guide vers Dol Amroth", "0x70068711", "Dol Amroth royal (Guide U38)",
+                             "le Gondor royal");
     hunterLocations:AddSkill("Guide vers Halrax", "0x70068713", "Halrax (Guide)");
     hunterLocations:AddSkill("Guide vers Lond Cirion", "0x70068717", "Lond Cirion (Guide)");
     hunterLocations:AddSkill("Guide vers Umbar", "0x70068718", "Umbar (Guide)");
@@ -192,7 +194,8 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Rassemblement : Forloi", "0x70036B5B", "Forloi (Rassemblement)");
     wardenLocations:AddSkill("Rassemblement : Aldburg", "0x7003DC7A", "Aldburg (Rassemblement)");
     wardenLocations:AddSkill("Rassemblement : Gouffre de Helm", "0x7003DC79", "Gouffre de Helm (Rassemblement)");
-    wardenLocations:AddSkill("Rassemblement : Dol Amroth", "0x70041198", "Dol Amroth (Rassemblement)");
+    wardenLocations:AddSkill("Rassemblement : Dol Amroth", "0x70041198", "Dol Amroth (Rassemblement)",
+                             "l'Ouest du Gondor");
     wardenLocations:AddSkill("Rassemblement : Arnach", "0x70043A66", "Arnach (Rassemblement)");
     wardenLocations:AddSkill("Rassemblement : Minas Tirith", "0x70044982", "Minas Tirith (Rassemblement)");
     wardenLocations:AddSkill("Rassemblement : Camp militaire", "0x700459AA", "Camp militaire (Rassemblement)");
@@ -227,7 +230,8 @@ function TravelDictionaries:CreateDictionaries()
     wardenLocations:AddSkill("Rassemblement à Jax Phanâl","0x7006870C", "Jax Phanâl (Rassemblement)");
     wardenLocations:AddSkill("Rassemblement à Umbar","0x7006870F","Umbar (Rassemblement)");
     wardenLocations:AddSkill("Rassemblement à Halrax","0x70068710", "Halrax (Rassemblement)");
-    wardenLocations:AddSkill("Rassemblement à Dol Amroth","0x70068712", "Dol Amroth (Rassemblement)");
+    wardenLocations:AddSkill("Rassemblement à Dol Amroth","0x70068712", "Dol Amroth royal (Rassemblement)",
+                             "le Gondor royal");
     wardenLocations:AddSkill("Rassemblement à Lond Cirion","0x70068715", "Lond Cirion (Rassemblement)");
     wardenLocations:AddSkill("Rassemblement à la taverne de l'Aigle sanglant","0x700697F3", "Taverne de l'Aigle sanglant (Rassemblement)");
 
@@ -238,27 +242,8 @@ function TravelDictionaries:CreateDictionaries()
     marinerLocations:AddSkill("Cap sur la Ville du Lac", "0x7006610C", "Ville du Lac (Naviguer)")
     marinerLocations:AddSkill("Naviguer vers l'Orée Noire", "0x7006610E", "Orée Noire (Naviguer)")
     marinerLocations:AddSkill("Naviguer vers Tinnudir", "0x7006610F", "Tinnudir (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Dol Amroth", "0x70066117", "Dol Amroth (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers le Pays de Bouc", "0x7006611A", "Pays de Bouc (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Pelargir", "0x7006611B", "Pelargir (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Sûri-kylä", "0x7006611C", "Sûri-kylä (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers la Lothlorien", "0x7006611E", "Lothlorien (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers le Gué de Sarn", "0x70066120", "le Gué de Sarn (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Neigebronne", "0x70066121", "Neigebronne (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Umbar", "0x700687BB", "Umbar (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Lond Cirion", "0x70066121", "Lond Cirion (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Jax Phanâl", "0x70066121", "Jax Phanâl (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Dol Amroth", "0x70066121", "Dol Amroth (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Halrax", "0x70066121", "Halrax (Naviguer)")
-
-    marinerLocations:AddSkill("Naviguer vers Celondim", "0x70066100", "Celondim (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers les Terres brunes", "0x70066101", "Terres brunes (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers le Quai des marchands", "0x70066105", "Quai des marchands (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Osgiliath après la bataille", "0x70066109", "Osgiliath après la bataille (Naviguer)")
-    marinerLocations:AddSkill("Cap sur la Ville du Lac", "0x7006610C", "Ville du Lac (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers l'Orée Noire", "0x7006610E", "Orée Noire (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Tinnudir", "0x7006610F", "Tinnudir (Naviguer)")
-    marinerLocations:AddSkill("Naviguer vers Dol Amroth", "0x70066117", "Dol Amroth (Naviguer)")
+    marinerLocations:AddSkill("Naviguer vers Dol Amroth", "0x70066117", "Dol Amroth (Naviguer)",
+                              "Dol Amroth en bonne compagnie.")
     marinerLocations:AddSkill("Naviguer vers le Pays de Bouc", "0x7006611A", "Pays de Bouc (Naviguer)")
     marinerLocations:AddSkill("Naviguer vers Pelargir", "0x7006611B", "Pelargir (Naviguer)")
     marinerLocations:AddSkill("Naviguer vers Sûri-kylä", "0x7006611C", "Sûri-kylä (Naviguer)")
@@ -268,13 +253,17 @@ function TravelDictionaries:CreateDictionaries()
     marinerLocations:AddSkill("Naviguer vers Umbar", "0x700687BB", "Umbar (Naviguer)");
     marinerLocations:AddSkill("Naviguer vers Lond Cirion", "0x700687BD", "Lond Cirion (Naviguer)");
     marinerLocations:AddSkill("Naviguer vers Jax Phanâl", "0x700687C0", "Jax Phanâl (Naviguer)");
-    marinerLocations:AddSkill("Naviguer vers Dol Amroth", "0x700687C1", "Dol Amroth (Naviguer)");
+    marinerLocations:AddSkill("Naviguer vers Dol Amroth", "0x700687C1", "Dol Amroth royal (Naviguer)",
+                              "le Gondor royal");
     marinerLocations:AddSkill("Naviguer vers Halrax", "0x700687C3", "Halrax (Naviguer)");
 
-    racialLocations:AddSkill("Retour à Bree", "0x700062F6", "Bree (Race)");
+    racialLocations:AddSkill("Retour à Bree", "0x700062F6", "Bree (Race)",
+                             "Permet de retourner");
     racialLocations:AddSkill("Retournez dans la Comté", "0x700062C8", "Comté (Race)");
-    racialLocations:AddSkill("Retour : Porte de Thorin", "0x70006346", "Porte de Thorin (Race)");
-    racialLocations:AddSkill("Retour à Fondcombe", "0x7000631F", "Fondcombe (Race)");
+    racialLocations:AddSkill("Retour : Porte de Thorin", "0x70006346", "Porte de Thorin (Race)",
+                             "Ceci vous permet de retourner");
+    racialLocations:AddSkill("Retour à Fondcombe", "0x7000631F", "Fondcombe (Race)",
+                             "Ceci vous permet de retourner");
     racialLocations:AddSkill("Retour à la maison", "0x70041A22", "Maison Beorning (Race)");
     racialLocations:AddSkill("Voyage vers Caras Galadhon, en Lothlórien", "0x70048C8C", "Caras Galadhon (Race)");
     racialLocations:AddSkill("Aller au Palais de Thorin", "0x70053C0F", "Palais de Thorin (Race)");
@@ -296,11 +285,14 @@ function TravelDictionaries:CreateDictionaries()
     genLocations:AddSkill("Retour à la maison de confrérie", "0x7000D047", "Maison de confrérie");
     genLocations:AddSkill("Retour à la maison d'un membre de confrérie", "0x70057C36", "Maison d'un membre de confrérie");
 
-    repLocations:AddSkill("Retour : Porte de Thorin", "0x7001BF91", "Porte de Thorin (Rep/Shop)");
-    repLocations:AddSkill("Retour à Bree", "0x7001BF90", "Retour à Bree (Rep/Shop)");
+    repLocations:AddSkill("Retour : Porte de Thorin", "0x7001BF91", "Porte de Thorin (Rep/Shop)",
+                          "Grâce à l'amitié qui vous");
+    repLocations:AddSkill("Retour à Bree", "0x7001BF90", "Retour à Bree (Rep/Shop)",
+                          "Grâce à votre amitié");
     repLocations:AddSkill("Retour au Marché de Lalia", "0x700364B1", "Retour au Marché de Lalia (Mithril)");
     repLocations:AddSkill("Retour à Grand'Cave", "0x70023262", "Retour à Grand'Cave (Shop)");
-    repLocations:AddSkill("Retour à Fondcombe", "0x70023263", "Retour à Fondcombe (Shop)");
+    repLocations:AddSkill("Retour à Fondcombe", "0x70023263", "Retour à Fondcombe (Shop)",
+                          "Grâce à votre amitié avec");
     repLocations:AddSkill("Retournez à Ost Guruth", "0x70020441", "Retournez à Ost Guruth (Rep)");
     repLocations:AddSkill("Retour dans la Forêt Noire", "0x7001F374", "Retour dans la Forêt Noire (Rep)");
     repLocations:AddSkill("Retour en Enedwaith", "0x70021FA2", "Retour en Enedwaith (Rep)");
@@ -311,7 +303,8 @@ function TravelDictionaries:CreateDictionaries()
     repLocations:AddSkill("Retour à Aldburg", "0x7003DC81", "Aldburg (Rep)");
     repLocations:AddSkill("Retour à Derunant", "0x7004128F", "Derunant (Rep)");
     repLocations:AddSkill("Retour au Gouffre de Helm", "0x7003DC82", "Gouffre de Helm(Rep)");
-    repLocations:AddSkill("Retour à Dol Amroth", "0x700411AC", "Dol Amroth (Rep)");
+    repLocations:AddSkill("Retour à Dol Amroth", "0x700411AC", "Dol Amroth (Rep)",
+                          "l'Ouest du Gondor");
     repLocations:AddSkill("Retournez à Arnach", "0x70043A6A", "Arnach (Rep)");
     repLocations:AddSkill("Retour à Minas Tirith", "0x7004497E", "Retour à Minas Tirith (Rep)");
     repLocations:AddSkill("Retour au camp militaire", "0x700459A9", "Camp militaire (Rep)");
@@ -352,7 +345,8 @@ function TravelDictionaries:CreateDictionaries()
     repLocations:AddSkill("Retournez à Pelargir", "0x700658EB", "Pelargir (Rep)");
     repLocations:AddSkill("Voyager vers l'Ordre de l'Aigle", "0x700686FE", "L'Ordre de l'Aigle (Rep)");
     repLocations:AddSkill("Retour à Umbar", "0x700686FF", "Umbar (Rep)");
-    repLocations:AddSkill("Retour à Dol Amroth", "0x70068700", "Dol Amroth (Rep U38)");
+    repLocations:AddSkill("Retour à Dol Amroth", "0x70068700", "Dol Amroth royal (Rep U38)",
+                          "le Gondor royal");
     repLocations:AddSkill("Retour à Jax Phanâl", "0x70068701", "Jax Phanâl (Rep)");
     repLocations:AddSkill("Retournez voir Halrax", "0x70068702", "Halrax (Rep)");
     repLocations:AddSkill("Retour à Lond Cirion", "0x70068703", "Lond Cirion (Rep)");

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -21,6 +21,8 @@ function TravelCommand:Execute(command, arguments)
         _G.travel:SetVisible(not _G.travel:IsVisible());
     elseif (arguments == "dump") then
         _G.travel:DoDump();
+    elseif (arguments == "scan") then
+        _G.travel:ManualSkillScan();
     elseif (arguments ~= nil) then
         TravelCommand:GetHelp();
     end

--- a/src/TravelWindow.lua
+++ b/src/TravelWindow.lua
@@ -1218,3 +1218,100 @@ function AddCallback(object, event, callback)
     end
     return callback;
 end
+
+-- for debug purposes
+function TravelWindow:ManualSkillScan()
+    local last = 0;
+    skillWindow=Turbine.UI.Lotro.Window()
+    skillWindow.cols=math.floor((Turbine.UI.Display:GetWidth()-10)/100)
+    skillWindow.rows=math.floor((Turbine.UI.Display:GetHeight()-105)/62)
+    skillWindow:SetSize(Turbine.UI.Display:GetWidth(),Turbine.UI.Display:GetHeight())
+    skillWindow:SetText("Skill Explorer")
+    skillWindow.StartCaption=Turbine.UI.Label()
+    skillWindow.StartCaption:SetParent(skillWindow)
+    skillWindow.StartCaption:SetText("Start:")
+    skillWindow.StartCaption:SetPosition(10,45)
+    skillWindow.StartCaption:SetSize(50,20)
+    skillWindow.Start=Turbine.UI.Lotro.TextBox()
+    skillWindow.Start:SetParent(skillWindow)
+    skillWindow.Start:SetPosition(65,45)
+    skillWindow.Start:SetSize(100,20)
+    skillWindow.Start:SetFont(Turbine.UI.Lotro.Font.Verdana16)
+    skillWindow.Prev=Turbine.UI.Lotro.Button()
+    skillWindow.Prev:SetParent(skillWindow)
+    skillWindow.Prev:SetSize(100,20)
+    skillWindow.Prev:SetPosition(170,45)
+    skillWindow.Prev:SetText("Previous")
+    skillWindow.Prev.Click=function()
+        local start=tonumber(skillWindow.Start:GetText())
+        if start==nil then start=0 end
+        start=start-skillWindow.rows*skillWindow.cols
+        if start<0 then start=0 end
+        skillWindow.Start:SetText(string.format("0x%x",start))
+        skillWindow.refresh()
+    end
+    skillWindow.Show=Turbine.UI.Lotro.Button()
+    skillWindow.Show:SetParent(skillWindow)
+    skillWindow.Show:SetSize(100,20)
+    skillWindow.Show:SetPosition(275,45)
+    skillWindow.Show:SetText("Refresh")
+    skillWindow.Show.Click=function()
+        skillWindow.refresh()
+    end
+    skillWindow.Next=Turbine.UI.Lotro.Button()
+    skillWindow.Next:SetParent(skillWindow)
+    skillWindow.Next:SetSize(100,20)
+    skillWindow.Next:SetPosition(380,45)
+    skillWindow.Next:SetText("Next")
+    skillWindow.Next.Click=function()
+        local start=tonumber(skillWindow.Start:GetText())
+        if start==nil then start=0 end
+        if last == 0 then
+            start=start+skillWindow.rows*skillWindow.cols
+        else
+            start = last
+        end
+        skillWindow.Start:SetText(string.format("0x%x",start))
+        skillWindow.refresh()
+    end
+    skillWindow:SetVisible(true)
+    skillWindow.QS={}
+    for row=1,skillWindow.rows do
+        skillWindow.QS[row]={}
+        for col=1,skillWindow.cols do
+            skillWindow.QS[row][col]=Turbine.UI.Lotro.Quickslot()
+            local qs=skillWindow.QS[row][col]
+            qs:SetParent(skillWindow)
+            qs:SetSize(34,34)
+            qs:SetPosition(col*100-32, row*62+23)
+            qs.label=Turbine.UI.Label()
+            qs.label:SetParent(skillWindow)
+            qs.label:SetSize(100,20)
+            qs.label:SetPosition(col*100-32, row*62+57)
+        end
+    end
+    skillWindow.refresh=function()
+        local start=tonumber(skillWindow.Start:GetText())
+        if start==nil then start=0 end
+
+        for row=1,skillWindow.rows do
+            local err = 0;
+            for col=1,skillWindow.cols do
+                repeat
+                    local qs=skillWindow.QS[row][col]
+                    local sc=Turbine.UI.Lotro.Shortcut();
+                    sc:SetType(Turbine.UI.Lotro.ShortcutType.Skill)
+                    local val=string.format("0x%x",start);
+                    start = start + 1;
+                    sc:SetData(val)
+                    local success, result=pcall(Turbine.UI.Lotro.Quickslot.SetShortcut,qs,sc)
+                    qs:SetVisible(success)
+                    qs.label:SetText(val)
+                    if not success then err = err + 1 end
+                until success or err > 10000
+            end
+        end
+        last = start;
+    end
+    skillWindow.Start:SetText("0x700697F2")
+end


### PR DESCRIPTION
I modified a visual skill scanner written by Garan on the lotro interface forums and was able to fill in the missing skill descriptions in english. ~~I have left it out of this PR, but if you want it, I can either add it to this one or post the resulting scanner somewhere else.~~

Stupid typo. I went ahead and included the debug scanner since I was rebasing anyway ( #5 ).

Made a hacky data-mining tool to grab the FR and DE translations for these skills ( #156 ).