### PR TITLE
Mini UI option

### DIFF
--- a/src/IndexedDictionary.lua
+++ b/src/IndexedDictionary.lua
@@ -157,3 +157,23 @@ function IndexedDictionary:IndexByName(name)
     -- return -1 since we did not find a key
     return -1;
 end
+
+-- function to check if a table contains a specific element
+function TableContains(tableToSearch, elementToSearchFor)
+    for i, value in pairs(tableToSearch) do
+        if (value == elementToSearchFor) then
+            return true;
+        end
+    end
+    return false;
+end
+
+-- function to check if a table contains a specific element index
+function TableIndex(tableToSearch, elementToSearchFor)
+    for i, value in pairs(tableToSearch) do
+        if (value == elementToSearchFor) then
+            return i;
+        end
+    end
+    return 0;
+end

--- a/src/IndexedDictionaryDe.lua
+++ b/src/IndexedDictionaryDe.lua
@@ -47,6 +47,7 @@ disableRepSkillsString = "Überlappung Deaktivieren";
 enableAllString = "Alle Aktivieren";
 disableAllString = "Alle Deaktivieren";
 ignoreEscString = "Escape ignorieren, um das Hauptfenster zu schließen";
+minWindowString = "Mini-Fenster verwenden";
 
 -- menu strings
 menuFiltersString = "Filter";

--- a/src/IndexedDictionaryDe.lua
+++ b/src/IndexedDictionaryDe.lua
@@ -48,6 +48,7 @@ enableAllString = "Alle Aktivieren";
 disableAllString = "Alle Deaktivieren";
 ignoreEscString = "Escape ignorieren, um das Hauptfenster zu schließen";
 minWindowString = "Mini-Fenster verwenden";
+fadeWindowString = "Geschwindigkeit des Fade-Fensters";
 
 -- menu strings
 menuFiltersString = "Filter";

--- a/src/IndexedDictionaryEn.lua
+++ b/src/IndexedDictionaryEn.lua
@@ -48,6 +48,7 @@ enableAllString = "Enable All";
 disableAllString = "Disable All";
 ignoreEscString = "Ignore Escape to close main window";
 minWindowString = "Use Mini-Window";
+fadeWindowString = "Fade Window Speed";
 
 -- menu strings
 menuFiltersString = "Filters";

--- a/src/IndexedDictionaryEn.lua
+++ b/src/IndexedDictionaryEn.lua
@@ -47,6 +47,7 @@ disableRepSkillsString = "Disable Overlapping";
 enableAllString = "Enable All";
 disableAllString = "Disable All";
 ignoreEscString = "Ignore Escape to close main window";
+minWindowString = "Use Mini-Window";
 
 -- menu strings
 menuFiltersString = "Filters";

--- a/src/IndexedDictionaryFr.lua
+++ b/src/IndexedDictionaryFr.lua
@@ -47,6 +47,7 @@ disableRepSkillsString = "Désactiver le chevauchement";
 enableAllString = "Activer tout";
 disableAllString = "Désactiver tout";
 ignoreEscString = "Ignorer Escape pour fermer la fenêtre principale";
+minWindowString = "Utiliser la mini-fenêtre";
 
 -- menu strings
 menuFiltersString = "Filtres";

--- a/src/IndexedDictionaryFr.lua
+++ b/src/IndexedDictionaryFr.lua
@@ -48,6 +48,7 @@ enableAllString = "Activer tout";
 disableAllString = "Désactiver tout";
 ignoreEscString = "Ignorer Escape pour fermer la fenêtre principale";
 minWindowString = "Utiliser la mini-fenêtre";
+fadeWindowString = "Fondu de la vitesse de la fenêtre";
 
 -- menu strings
 menuFiltersString = "Filtres";

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -1,5 +1,12 @@
 import "TravelWindowII.src";
 
+-- create shortcuts to the bitop functions
+bit = TravelWindowII.bit;
+hasbit = TravelWindowII.hasbit;
+setbit = TravelWindowII.setbit;
+clearbit = TravelWindowII.clearbit;
+togglebit = TravelWindowII.togglebit;
+
 DefAlpha = 0.92;
 Settings = {};
 SettingsStrings = {};
@@ -27,6 +34,28 @@ TravelInfo = TravelDictionary();
 
 -- set up all the shortcuts
 SetShortcuts();
+
+local PluginManagerOptionsPanel = Turbine.UI.Control()
+PluginManagerOptionsPanel:SetSize(500, 200)
+
+plugin.GetOptionsPanel = function()
+    return PluginManagerOptionsPanel;
+end
+
+OptionsWindow = TravelWindowII.src.OptionsWindow();
+local OptionsButton = Turbine.UI.Lotro.Button()
+OptionsButton:SetParent(PluginManagerOptionsPanel)
+OptionsButton:SetPosition(100, 100)
+OptionsButton:SetSize(200,15)
+OptionsButton:SetText(menuOptionsString)
+OptionsButton:SetVisible(true)
+
+OptionsButton.Click = function()
+    OptionsWindow:SetVisible(true);
+end
+
+-- configure the external toggle button
+ToggleButton = TravelWindowII.src.TravelButton();
 
 -- create the travel window
 _G.travel = TravelWindow();

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -58,7 +58,8 @@ end
 ToggleButton = TravelWindowII.src.TravelButton();
 
 -- create the travel window
-_G.travel = TravelWindow();
+_G.travel = TravelWindow(Settings.useMinWindow);
+
 NewShortcutEvent = function()
     _G.travel.dirty = true; -- reset list of shortcuts
     _G.travel:SetItems(); -- redraw current window

--- a/src/Main.lua
+++ b/src/Main.lua
@@ -1,11 +1,53 @@
 import "TravelWindowII.src";
 
+DefAlpha = 0.92;
+Settings = {};
+SettingsStrings = {};
+TravelShortcuts = {}; -- put all the shortcuts into one table
+TrainedSkills = Turbine.Gameplay.SkillList;
+
+-- get the player class and race
+player = Turbine.Gameplay.LocalPlayer.GetInstance();
+PlayerClass = player:GetClass();
+PlayerAlignment = player:GetAlignment();
+PlayerRace = player:GetRace();
+-- set the racial index used later in multiple places
+SetPlayerRaceKey();
+-- get the list of trained skills the player has
+if (Turbine.Gameplay.LocalPlayer.GetTrainedSkills ~= nil) then
+    TrainedSkills = player:GetTrainedSkills();
+end
+
+-- load the player saved settings
+LoadSettings();
+
+-- create the lists of travel locations and the shortcuts
+-- that are used to execute them
+TravelInfo = TravelDictionary();
+
+-- set up all the shortcuts
+SetShortcuts();
+
 -- create the travel window
 _G.travel = TravelWindow();
+NewShortcutEvent = function()
+    _G.travel.dirty = true; -- reset list of shortcuts
+    _G.travel:SetItems(); -- redraw current window
+end
+
+MapWindow:VerifyMapSkillIds("Hunter");
+MapWindow:VerifyMapSkillIds("Warden");
+MapWindow:VerifyMapSkillIds("Mariner");
+MapWindow:VerifyMapSkillIds("Reputation");
+
+Plugins["Travel Window II"].Load = function(sender, args)
+    Turbine.Shell.WriteLine("<u><rgb=#DAA520>Travel Window II " .. Plugins["Travel Window II"]:GetVersion() ..
+                            " by Hyoss</rgb></u>");
+end
 
 -- handle unload event and save settings
 plugin.Unload = function()
-    _G.travel:SaveSettings();
+    SaveSettings();
 end
 
 -- create a new command line command for the travel window
@@ -14,7 +56,7 @@ TravelCommand = Turbine.ShellCommand();
 -- handle the travel commands
 function TravelCommand:Execute(command, arguments)
     if (arguments == "show") then
-        _G.travel:CheckSkills(false);
+        CheckSkills(false);
         _G.travel:SetVisible(true);
     elseif (arguments == "hide") then
         _G.travel:SetVisible(false);

--- a/src/MapWindow.lua
+++ b/src/MapWindow.lua
@@ -18,13 +18,12 @@ MapType = {
     HARADWAITH = 7,
 };
 
-function MapWindow:Constructor(parent, map)
+function MapWindow:Constructor(map)
     Turbine.UI.Window.Constructor(self);
 
     --  add a check to see if we load completely
     self.loaded = false;
 
-    self.mainWindow = parent;
     self.mapType = map;
     self.debug = false; -- enable to position shortcuts on the map
 

--- a/src/OptionsPanel.lua
+++ b/src/OptionsPanel.lua
@@ -515,7 +515,6 @@ function OptionsPanel:AddSkillItemForEnabling(id, label)
     check:SetPosition(10, 0);
     check:SetChecked(Settings.enabled[id]);
     check:SetParent(control);
-    check:SetWantsUpdates(true);
     check:SetVisible(true);
     check.skillId = id;
     table.insert(self.checks, check);

--- a/src/OptionsPanel.lua
+++ b/src/OptionsPanel.lua
@@ -563,7 +563,7 @@ function OptionsPanel:AddBoxes()
 
     -- do the check skills
     self.checkSkillsButton.Click = function(sender, args)
-        self.mainWindow:CheckSkills(true);
+        CheckSkills(true);
     end
 
     local next = next; -- optimization

--- a/src/OptionsPanel.lua
+++ b/src/OptionsPanel.lua
@@ -8,7 +8,7 @@ import "TravelWindowII.src.utils.BitOps";
 
 OptionsPanel = class(Turbine.UI.Control);
 
-function OptionsPanel:Constructor(parent)
+function OptionsPanel:Constructor()
     Turbine.UI.Control.Constructor(self);
 
     --  add a check to see if we load completely
@@ -28,7 +28,6 @@ function OptionsPanel:Constructor(parent)
     -- create array of labels and check boxes
     self.labels = {};
     self.checks = {};
-    self.mainWindow = parent;
 
     -- keep track of which item is selected on the sort tab
     self.sortSelectedIndex = 1;
@@ -89,8 +88,8 @@ function OptionsPanel:Constructor(parent)
     -- have the main window close the options
     self.VisibleChanged = function(sender, args)
         if (self:IsVisible() == false) then
-            if (parent ~= nil) then
-                parent:CloseOptions();
+            if (_G.travel ~= nil) then
+                _G.travel:CloseOptions();
             end
         end
     end
@@ -310,7 +309,7 @@ function OptionsPanel:AddGeneralItems()
 
     -- do the settings reset
     self.resetButton.Click = function(sender, args)
-        self.mainWindow:ResetSettings();
+        _G.travel:ResetSettings();
     end
 
     -- set the hide on start option when changed
@@ -320,7 +319,7 @@ function OptionsPanel:AddGeneralItems()
         else
             Settings.hideOnStart = 0;
         end
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
     end
 
     -- set the hide on combat option when changed
@@ -330,7 +329,7 @@ function OptionsPanel:AddGeneralItems()
         else
             Settings.hideOnCombat = 0;
         end
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
     end
 
     -- set the close on travel option when changed
@@ -340,7 +339,7 @@ function OptionsPanel:AddGeneralItems()
         else
             Settings.hideOnTravel = 0;
         end
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
     end
 
     -- set the ignore escape to close option when changed
@@ -350,7 +349,7 @@ function OptionsPanel:AddGeneralItems()
         else
             Settings.ignoreEsc = 0;
         end
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
     end
 
     -- set the show toggle button option when changed
@@ -360,8 +359,8 @@ function OptionsPanel:AddGeneralItems()
         else
             Settings.showButton = 0;
         end
-        self.mainWindow:UpdateSettings();
-        self.mainWindow.ToggleButton:SetVisible(sender:IsChecked());
+        _G.travel:UpdateSettings();
+        ToggleButton:SetVisible(sender:IsChecked());
     end
 
     -- set the fire on pulldown selection option when changed
@@ -371,7 +370,7 @@ function OptionsPanel:AddGeneralItems()
         else
             Settings.pulldownTravel = 0;
         end
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
     end
 
     -- update settings when sliders change
@@ -384,8 +383,8 @@ function OptionsPanel:AddGeneralItems()
 
         -- do updates
         Settings.toggleMinOpacity = self.toggleMinScrollBar:GetValue() / 100;
-        self.mainWindow:UpdateOpacity();
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateOpacity();
+        _G.travel:UpdateSettings();
     end
 
     self.toggleMaxScrollBar.ValueChanged = function(sender, args)
@@ -397,8 +396,8 @@ function OptionsPanel:AddGeneralItems()
 
         -- do updates
         Settings.toggleMaxOpacity = self.toggleMaxScrollBar:GetValue() / 100;
-        self.mainWindow:UpdateOpacity();
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateOpacity();
+        _G.travel:UpdateSettings();
 
     end
 
@@ -412,8 +411,8 @@ function OptionsPanel:AddGeneralItems()
 
         -- do updates
         Settings.mainMinOpacity = self.mainMinScrollBar:GetValue() / 100;
-        self.mainWindow:UpdateOpacity();
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateOpacity();
+        _G.travel:UpdateSettings();
     end
 
     self.mainMaxScrollBar.ValueChanged = function(sender, args)
@@ -425,8 +424,8 @@ function OptionsPanel:AddGeneralItems()
 
         -- do updates
         Settings.mainMaxOpacity = self.mainMaxScrollBar:GetValue() / 100;
-        self.mainWindow:UpdateOpacity();
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateOpacity();
+        _G.travel:UpdateSettings();
     end
 end
 
@@ -494,12 +493,12 @@ function OptionsPanel:AddSkillItemForEnabling(id, label)
         shortcutIndex = TableIndex(Settings.order, id);
         TravelShortcuts[shortcutIndex]:SetEnabled(sender:IsChecked());
 
-        self.mainWindow.dirty = true;
+        _G.travel.dirty = true;
         if not self.disableUpdates then
-            self.mainWindow:UpdateSettings();
+            _G.travel:UpdateSettings();
         end
-        if self.mainWindow.mapWindow ~= nil then
-            self.mainWindow.mapWindow:UpdateShortcut(id, sender:IsChecked());
+        if _G.travel.mapWindow ~= nil then
+            _G.travel.mapWindow:UpdateShortcut(id, sender:IsChecked());
         end
     end
 end
@@ -757,7 +756,7 @@ function OptionsPanel:EnableOverlapSkills(enable)
         end
     end
     self.disableUpdates = false;
-    self.mainWindow:UpdateSettings(); -- force an update now
+    _G.travel:UpdateSettings(); -- force an update now
 end
 
 function OptionsPanel:EnableAll(enable)
@@ -766,7 +765,7 @@ function OptionsPanel:EnableAll(enable)
         self.checks[i]:SetChecked(enable);
     end
     self.disableUpdates = false;
-    self.mainWindow:UpdateSettings(); -- force an update now
+    _G.travel:UpdateSettings(); -- force an update now
 end
 
 -- function to add the list of shortcuts to the sort tab
@@ -871,7 +870,7 @@ function OptionsPanel:AddSortButtons()
         end
 
         -- update the main window shortcuts and settings
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
     end
 
     -- handle the move up button click
@@ -885,7 +884,7 @@ function OptionsPanel:AddSortButtons()
         self:SwapShortcuts(self.sortSelectedIndex, self.sortSelectedIndex - 1);
 
         -- update the main window shortcuts and settings
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
 
         -- decrease the selected index
         self.sortSelectedIndex = self.sortSelectedIndex - 1;
@@ -902,7 +901,7 @@ function OptionsPanel:AddSortButtons()
         self:SwapShortcuts(self.sortSelectedIndex, self.sortSelectedIndex + 1);
 
         -- update the main window shortcuts and settings
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
 
         -- increase the selected index
         self.sortSelectedIndex = self.sortSelectedIndex + 1;
@@ -920,7 +919,7 @@ function OptionsPanel:AddSortButtons()
         end
 
         -- update the main window shortcuts and settings
-        self.mainWindow:UpdateSettings();
+        _G.travel:UpdateSettings();
     end
 end
 
@@ -947,6 +946,6 @@ function OptionsPanel:SwapShortcuts(first, second)
         local tempShortcut = TravelShortcuts[first];
         TravelShortcuts[first] = TravelShortcuts[second];
         TravelShortcuts[second] = tempShortcut;
-        self.mainWindow.dirty = true;
+        _G.travel.dirty = true;
     end
 end

--- a/src/OptionsPanel.lua
+++ b/src/OptionsPanel.lua
@@ -294,7 +294,7 @@ function OptionsPanel:AddGeneralItems()
     self.mainMinSlidersLabel:SetText(minString);
     self.mainMinSlidersLabel:SetVisible(true);
 
-    -- toggle button min slider
+    -- main window min slider
     self.mainMinScrollBar = Turbine.UI.Lotro.ScrollBar();
     self.mainMinScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
     self.mainMinScrollBar:SetSize(400, 10);
@@ -304,7 +304,7 @@ function OptionsPanel:AddGeneralItems()
     self.mainMinScrollBar:SetValue(Settings.mainMinOpacity * 100);
     self.mainMinScrollBar:SetParent(self.GeneralTab);
 
-    -- toggle button max slider
+    -- main window max slider label
     self.mainMaxSlidersLabel = Turbine.UI.Label();
     self.mainMaxSlidersLabel:SetSize(50, 20);
     self.mainMaxSlidersLabel:SetPosition(20, self:NextY(15));
@@ -313,7 +313,7 @@ function OptionsPanel:AddGeneralItems()
     self.mainMaxSlidersLabel:SetText(maxString);
     self.mainMaxSlidersLabel:SetVisible(true);
 
-    -- toggle button max slider
+    -- main window max slider
     self.mainMaxScrollBar = Turbine.UI.Lotro.ScrollBar();
     self.mainMaxScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
     self.mainMaxScrollBar:SetSize(400, 10);
@@ -322,6 +322,25 @@ function OptionsPanel:AddGeneralItems()
     self.mainMaxScrollBar:SetMaximum(100);
     self.mainMaxScrollBar:SetValue(Settings.mainMaxOpacity * 100);
     self.mainMaxScrollBar:SetParent(self.GeneralTab);
+
+    -- fade out slider label
+    self.mainFadeSlidersLabel = Turbine.UI.Label();
+    self.mainFadeSlidersLabel:SetSize(300, 20);
+    self.mainFadeSlidersLabel:SetPosition(20, self:NextY(25));
+    self.mainFadeSlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
+    self.mainFadeSlidersLabel:SetParent(self.GeneralTab);
+    self.mainFadeSlidersLabel:SetText(fadeWindowString);
+    self.mainFadeSlidersLabel:SetVisible(true);
+
+    -- fade out slider
+    self.mainFadeScrollBar = Turbine.UI.Lotro.ScrollBar();
+    self.mainFadeScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
+    self.mainFadeScrollBar:SetSize(450, 10);
+    self.mainFadeScrollBar:SetPosition(20, self:NextY(25));
+    self.mainFadeScrollBar:SetMinimum(1);
+    self.mainFadeScrollBar:SetMaximum(51);
+    self.mainFadeScrollBar:SetValue(Settings.fadeOutSteps);
+    self.mainFadeScrollBar:SetParent(self.GeneralTab);
 
     -- reset all setting button
     self.resetButton = Turbine.UI.Lotro.Button();
@@ -459,6 +478,12 @@ function OptionsPanel:AddGeneralItems()
 
         -- do updates
         Settings.mainMaxOpacity = self.mainMaxScrollBar:GetValue() / 100;
+        _G.travel:UpdateOpacity();
+        _G.travel:UpdateSettings();
+    end
+
+    self.mainFadeScrollBar.ValueChanged = function(sender, args)
+        Settings.fadeOutSteps = self.mainFadeScrollBar:GetValue();
         _G.travel:UpdateOpacity();
         _G.travel:UpdateSettings();
     end

--- a/src/OptionsPanel.lua
+++ b/src/OptionsPanel.lua
@@ -101,12 +101,36 @@ function OptionsPanel:GetLoaded()
     return self.loaded;
 end
 
+function OptionsPanel:NextY(offset)
+    self.optionHeight = self.optionHeight + offset;
+    return self.optionHeight;
+end
+
 -- function to add items to the general tab
 function OptionsPanel:AddGeneralItems()
+    self.optionHeight = 0;
+
+    -- label for hide window on start option
+    self.UseMinWindowLabel = Turbine.UI.Label();
+    self.UseMinWindowLabel:SetSize(300, 20);
+    self.UseMinWindowLabel:SetPosition(20, self:NextY(20));
+    self.UseMinWindowLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
+    self.UseMinWindowLabel:SetParent(self.GeneralTab);
+    self.UseMinWindowLabel:SetText(minWindowString);
+    self.UseMinWindowLabel:SetVisible(true);
+
+    -- checkbox for hide window on start option
+    self.UseMinWindowCheck = Turbine.UI.Lotro.CheckBox();
+    self.UseMinWindowCheck:SetSize(19, 19);
+    self.UseMinWindowCheck:SetPosition(450, self:NextY(0));
+    self.UseMinWindowCheck:SetChecked(Settings.useMinWindow == 1);
+    self.UseMinWindowCheck:SetParent(self.GeneralTab);
+    self.UseMinWindowCheck:SetVisible(true);
+
     -- label for hide window on start option
     self.HideOnStartLabel = Turbine.UI.Label();
     self.HideOnStartLabel:SetSize(300, 20);
-    self.HideOnStartLabel:SetPosition(20, 20);
+    self.HideOnStartLabel:SetPosition(20, self:NextY(30));
     self.HideOnStartLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.HideOnStartLabel:SetParent(self.GeneralTab);
     self.HideOnStartLabel:SetText(hideString);
@@ -115,7 +139,7 @@ function OptionsPanel:AddGeneralItems()
     -- checkbox for hide window on start option
     self.HideOnStartCheck = Turbine.UI.Lotro.CheckBox();
     self.HideOnStartCheck:SetSize(19, 19);
-    self.HideOnStartCheck:SetPosition(450, 20);
+    self.HideOnStartCheck:SetPosition(450, self:NextY(0));
     self.HideOnStartCheck:SetChecked(Settings.hideOnStart == 1);
     self.HideOnStartCheck:SetParent(self.GeneralTab);
     self.HideOnStartCheck:SetVisible(true);
@@ -123,7 +147,7 @@ function OptionsPanel:AddGeneralItems()
     -- label for hide on combat option
     self.HideOnCombatLabel = Turbine.UI.Label();
     self.HideOnCombatLabel:SetSize(300, 20);
-    self.HideOnCombatLabel:SetPosition(20, 50);
+    self.HideOnCombatLabel:SetPosition(20, self:NextY(30));
     self.HideOnCombatLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.HideOnCombatLabel:SetParent(self.GeneralTab);
     self.HideOnCombatLabel:SetText(hideOnCombatString);
@@ -132,7 +156,7 @@ function OptionsPanel:AddGeneralItems()
     -- checkbox for hide on combat option
     self.HideOnCombatCheck = Turbine.UI.Lotro.CheckBox();
     self.HideOnCombatCheck:SetSize(19, 19);
-    self.HideOnCombatCheck:SetPosition(450, 50);
+    self.HideOnCombatCheck:SetPosition(450, self:NextY(0));
     self.HideOnCombatCheck:SetChecked(Settings.hideOnCombat == 1);
     self.HideOnCombatCheck:SetParent(self.GeneralTab);
     self.HideOnCombatCheck:SetVisible(true);
@@ -140,7 +164,7 @@ function OptionsPanel:AddGeneralItems()
     -- label for option to close window on travel skill use
     self.hideOnTravelLabel = Turbine.UI.Label();
     self.hideOnTravelLabel:SetSize(300, 20);
-    self.hideOnTravelLabel:SetPosition(20, 80);
+    self.hideOnTravelLabel:SetPosition(20, self:NextY(30));
     self.hideOnTravelLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.hideOnTravelLabel:SetParent(self.GeneralTab);
     self.hideOnTravelLabel:SetText(hideOnTravelString);
@@ -149,7 +173,7 @@ function OptionsPanel:AddGeneralItems()
     -- checkbox for option to close window on travel skill use
     self.hideOnTravelCheck = Turbine.UI.Lotro.CheckBox();
     self.hideOnTravelCheck:SetSize(19, 19);
-    self.hideOnTravelCheck:SetPosition(450, 80);
+    self.hideOnTravelCheck:SetPosition(450, self:NextY(0));
     self.hideOnTravelCheck:SetChecked(Settings.hideOnTravel == 1);
     self.hideOnTravelCheck:SetParent(self.GeneralTab);
     self.hideOnTravelCheck:SetVisible(true);
@@ -157,7 +181,7 @@ function OptionsPanel:AddGeneralItems()
     -- label for ignore escape to close option
     self.ignoreEscLabel = Turbine.UI.Label();
     self.ignoreEscLabel:SetSize(300, 20);
-    self.ignoreEscLabel:SetPosition(20, 110);
+    self.ignoreEscLabel:SetPosition(20, self:NextY(30));
     self.ignoreEscLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.ignoreEscLabel:SetParent(self.GeneralTab);
     self.ignoreEscLabel:SetText(ignoreEscString);
@@ -166,7 +190,7 @@ function OptionsPanel:AddGeneralItems()
     -- checkbox for ignore escape to close option
     self.ignoreEscCheck = Turbine.UI.Lotro.CheckBox();
     self.ignoreEscCheck:SetSize(19, 19);
-    self.ignoreEscCheck:SetPosition(450, 110);
+    self.ignoreEscCheck:SetPosition(450, self:NextY(0));
     self.ignoreEscCheck:SetChecked(Settings.ignoreEsc == 1);
     self.ignoreEscCheck:SetParent(self.GeneralTab);
     self.ignoreEscCheck:SetVisible(true);
@@ -174,7 +198,7 @@ function OptionsPanel:AddGeneralItems()
     -- label for show toggle button option
     self.ShowButtonLabel = Turbine.UI.Label();
     self.ShowButtonLabel:SetSize(300, 20);
-    self.ShowButtonLabel:SetPosition(20, 140);
+    self.ShowButtonLabel:SetPosition(20, self:NextY(30));
     self.ShowButtonLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.ShowButtonLabel:SetParent(self.GeneralTab);
     self.ShowButtonLabel:SetText(toggleString);
@@ -183,7 +207,7 @@ function OptionsPanel:AddGeneralItems()
     -- checkbox for show toggle button option
     self.ShowButtonCheck = Turbine.UI.Lotro.CheckBox();
     self.ShowButtonCheck:SetSize(19, 19);
-    self.ShowButtonCheck:SetPosition(450, 140);
+    self.ShowButtonCheck:SetPosition(450, self:NextY(0));
     self.ShowButtonCheck:SetChecked(Settings.showButton == 1);
     self.ShowButtonCheck:SetParent(self.GeneralTab);
     self.ShowButtonCheck:SetVisible(true);
@@ -191,7 +215,7 @@ function OptionsPanel:AddGeneralItems()
     -- label for option to fire skill on pulldown selection
     self.PulldownTravelLabel = Turbine.UI.Label();
     self.PulldownTravelLabel:SetSize(300, 20);
-    self.PulldownTravelLabel:SetPosition(20, 170);
+    self.PulldownTravelLabel:SetPosition(20, self:NextY(30));
     self.PulldownTravelLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.PulldownTravelLabel:SetParent(self.GeneralTab);
     self.PulldownTravelLabel:SetText(pulldownTravelString);
@@ -200,7 +224,7 @@ function OptionsPanel:AddGeneralItems()
     -- checkbox for option to fire skill on pulldown selection
     self.PulldownTravelCheck = Turbine.UI.Lotro.CheckBox();
     self.PulldownTravelCheck:SetSize(19, 19);
-    self.PulldownTravelCheck:SetPosition(450, 170);
+    self.PulldownTravelCheck:SetPosition(450, self:NextY(0));
     self.PulldownTravelCheck:SetChecked(Settings.pulldownTravel == 1);
     self.PulldownTravelCheck:SetParent(self.GeneralTab);
     self.PulldownTravelCheck:SetVisible(true);
@@ -208,7 +232,7 @@ function OptionsPanel:AddGeneralItems()
     -- label for toggle button sliders
     self.toggleSlidersLabel = Turbine.UI.Label();
     self.toggleSlidersLabel:SetSize(300, 20);
-    self.toggleSlidersLabel:SetPosition(20, 200);
+    self.toggleSlidersLabel:SetPosition(20, self:NextY(30));
     self.toggleSlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.toggleSlidersLabel:SetParent(self.GeneralTab);
     self.toggleSlidersLabel:SetText(toggleSlidersString);
@@ -217,7 +241,7 @@ function OptionsPanel:AddGeneralItems()
     -- toggle button min slider label
     self.toggleMinSlidersLabel = Turbine.UI.Label();
     self.toggleMinSlidersLabel:SetSize(50, 20);
-    self.toggleMinSlidersLabel:SetPosition(20, 220);
+    self.toggleMinSlidersLabel:SetPosition(20, self:NextY(20));
     self.toggleMinSlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.toggleMinSlidersLabel:SetParent(self.GeneralTab);
     self.toggleMinSlidersLabel:SetText(minString);
@@ -227,7 +251,7 @@ function OptionsPanel:AddGeneralItems()
     self.toggleMinScrollBar = Turbine.UI.Lotro.ScrollBar();
     self.toggleMinScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
     self.toggleMinScrollBar:SetSize(400, 10);
-    self.toggleMinScrollBar:SetPosition(70, 225);
+    self.toggleMinScrollBar:SetPosition(70, self:NextY(5));
     self.toggleMinScrollBar:SetMinimum(0);
     self.toggleMinScrollBar:SetMaximum(100);
     self.toggleMinScrollBar:SetValue(Settings.toggleMinOpacity * 100);
@@ -236,7 +260,7 @@ function OptionsPanel:AddGeneralItems()
     -- toggle button max slider
     self.toggleMaxSlidersLabel = Turbine.UI.Label();
     self.toggleMaxSlidersLabel:SetSize(50, 20);
-    self.toggleMaxSlidersLabel:SetPosition(20, 240);
+    self.toggleMaxSlidersLabel:SetPosition(20, self:NextY(15));
     self.toggleMaxSlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.toggleMaxSlidersLabel:SetParent(self.GeneralTab);
     self.toggleMaxSlidersLabel:SetText(maxString);
@@ -246,7 +270,7 @@ function OptionsPanel:AddGeneralItems()
     self.toggleMaxScrollBar = Turbine.UI.Lotro.ScrollBar();
     self.toggleMaxScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
     self.toggleMaxScrollBar:SetSize(400, 10);
-    self.toggleMaxScrollBar:SetPosition(70, 245);
+    self.toggleMaxScrollBar:SetPosition(70, self:NextY(5));
     self.toggleMaxScrollBar:SetMinimum(0);
     self.toggleMaxScrollBar:SetMaximum(100);
     self.toggleMaxScrollBar:SetValue(Settings.toggleMaxOpacity * 100);
@@ -255,7 +279,7 @@ function OptionsPanel:AddGeneralItems()
     -- label for main window sliders
     self.SlidersLabel = Turbine.UI.Label();
     self.SlidersLabel:SetSize(300, 20);
-    self.SlidersLabel:SetPosition(20, 270);
+    self.SlidersLabel:SetPosition(20, self:NextY(25));
     self.SlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.SlidersLabel:SetParent(self.GeneralTab);
     self.SlidersLabel:SetText(mainSlidersString);
@@ -264,7 +288,7 @@ function OptionsPanel:AddGeneralItems()
     -- main window min slider label
     self.mainMinSlidersLabel = Turbine.UI.Label();
     self.mainMinSlidersLabel:SetSize(50, 20);
-    self.mainMinSlidersLabel:SetPosition(20, 290);
+    self.mainMinSlidersLabel:SetPosition(20, self:NextY(20));
     self.mainMinSlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.mainMinSlidersLabel:SetParent(self.GeneralTab);
     self.mainMinSlidersLabel:SetText(minString);
@@ -274,7 +298,7 @@ function OptionsPanel:AddGeneralItems()
     self.mainMinScrollBar = Turbine.UI.Lotro.ScrollBar();
     self.mainMinScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
     self.mainMinScrollBar:SetSize(400, 10);
-    self.mainMinScrollBar:SetPosition(70, 295);
+    self.mainMinScrollBar:SetPosition(70, self:NextY(5));
     self.mainMinScrollBar:SetMinimum(0);
     self.mainMinScrollBar:SetMaximum(100);
     self.mainMinScrollBar:SetValue(Settings.mainMinOpacity * 100);
@@ -283,7 +307,7 @@ function OptionsPanel:AddGeneralItems()
     -- toggle button max slider
     self.mainMaxSlidersLabel = Turbine.UI.Label();
     self.mainMaxSlidersLabel:SetSize(50, 20);
-    self.mainMaxSlidersLabel:SetPosition(20, 310);
+    self.mainMaxSlidersLabel:SetPosition(20, self:NextY(15));
     self.mainMaxSlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
     self.mainMaxSlidersLabel:SetParent(self.GeneralTab);
     self.mainMaxSlidersLabel:SetText(maxString);
@@ -293,7 +317,7 @@ function OptionsPanel:AddGeneralItems()
     self.mainMaxScrollBar = Turbine.UI.Lotro.ScrollBar();
     self.mainMaxScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
     self.mainMaxScrollBar:SetSize(400, 10);
-    self.mainMaxScrollBar:SetPosition(70, 315);
+    self.mainMaxScrollBar:SetPosition(70, self:NextY(5));
     self.mainMaxScrollBar:SetMinimum(0);
     self.mainMaxScrollBar:SetMaximum(100);
     self.mainMaxScrollBar:SetValue(Settings.mainMaxOpacity * 100);
@@ -310,6 +334,17 @@ function OptionsPanel:AddGeneralItems()
     -- do the settings reset
     self.resetButton.Click = function(sender, args)
         _G.travel:ResetSettings();
+    end
+
+    self.UseMinWindowCheck.CheckedChanged = function(sender, args)
+        if (sender:IsChecked()) then
+            Settings.useMinWindow = 1;
+        else
+            Settings.useMinWindow = 0;
+        end
+        _G.travel:Close();
+        _G.travel = nil;
+        _G.travel = TravelWindow(Settings.useMinWindow);
     end
 
     -- set the hide on start option when changed

--- a/src/OptionsWindow.lua
+++ b/src/OptionsWindow.lua
@@ -8,7 +8,7 @@ import "TravelWindowII.src.utils.BitOps";
 
 OptionsWindow = class(Turbine.UI.Lotro.Window);
 
-function OptionsWindow:Constructor(parent)
+function OptionsWindow:Constructor()
     Turbine.UI.Lotro.Window.Constructor(self);
 
     self.loaded = false;
@@ -27,7 +27,7 @@ function OptionsWindow:Constructor(parent)
     self:SetOpacity(1);
 
     -- add the main options panel to the window
-    self.Panel = TravelWindowII.src.OptionsPanel(parent);
+    self.Panel = TravelWindowII.src.OptionsPanel();
     self.Panel:SetParent(self);
     self.Panel:SetPosition(0, 35);
 
@@ -37,8 +37,8 @@ function OptionsWindow:Constructor(parent)
     -- have the main window close the options
     self.VisibleChanged = function(sender, args)
         if (self:IsVisible() == false) then
-            if (parent ~= nil) then
-                parent:CloseOptions();
+            if (_G.travel ~= nil) then
+                _G.travel:CloseOptions();
             end
         end
     end

--- a/src/OrendarUIMods/ComboBox.lua
+++ b/src/OrendarUIMods/ComboBox.lua
@@ -51,11 +51,10 @@ function ComboBox:Constructor(toplevel)
     self.arrow:SetMouseVisible(false);
 
     -- drop down window
-    self.dropDownWindow = Turbine.UI.Extensions.SimpleWindow();
+    self.dropDownWindow = Turbine.UI.Window();
     self.dropDownWindow:SetBackColor(ComboBox.DisabledColor);
     self.dropDownWindow:SetZOrder(98);
     self.dropDownWindow:SetVisible(false);
-    self.dropDownWindow:SetFadeSpeed(0.01);
 
     -- list scroll bar        
     self.scrollBar = Turbine.UI.Lotro.ScrollBar();

--- a/src/SettingsMenu.lua
+++ b/src/SettingsMenu.lua
@@ -156,7 +156,7 @@ function SettingsMenu:Update(string)
     elseif (string == menuOptionsString) then
         self.parent:OpenOptions();
     elseif (string == menuSkillsString) then
-        self.parent:CheckSkills(true);
+        CheckSkills(true);
     elseif (string == moorMapString) then
         self.parent:OpenMapWindow(MapType.CREEPS);
     elseif (string == eriadorMapString) then

--- a/src/SettingsMenu.lua
+++ b/src/SettingsMenu.lua
@@ -6,13 +6,6 @@ SettingsMenu = class(Turbine.UI.ContextMenu)
 function SettingsMenu:Constructor(parentWindow)
     Turbine.UI.ContextMenu.Constructor(self);
 
-    -- create shortcuts to the bitop functions
-    bit = TravelWindowII.bit;
-    hasbit = TravelWindowII.hasbit;
-    setbit = TravelWindowII.setbit;
-    clearbit = TravelWindowII.clearbit;
-    togglebit = TravelWindowII.togglebit;
-
     -- set the default values
     self.mode = 1;
     self.filters = 0x0F;
@@ -180,3 +173,384 @@ function SettingsMenu:Update(string)
     self.parent:SetOpacity(Settings.mainMinOpacity);
 end
 
+function SetPlayerRaceKey()
+    -- map player race to racial travel skill index for insertion into available travel skills
+    if (PlayerRace == Turbine.Gameplay.Race.Dwarf) then
+        PlayerRaceKey = 3;
+    elseif (PlayerRace == Turbine.Gameplay.Race.Elf) then
+        PlayerRaceKey = 4;
+    elseif (PlayerRace == Turbine.Gameplay.Race.Hobbit) then
+        PlayerRaceKey = 2;
+    elseif (PlayerRace == Turbine.Gameplay.Race.Man) then
+        PlayerRaceKey = 1;
+    elseif (PlayerRace == Turbine.Gameplay.Race.Beorning) then
+        PlayerRaceKey = 5;
+    elseif (PlayerRace == Turbine.Gameplay.Race.HighElf) then
+        PlayerRaceKey = 6;
+    elseif (PlayerRace == Turbine.Gameplay.Race.StoutAxe) then
+        PlayerRaceKey = 7;
+    elseif (PlayerRace == Turbine.Gameplay.Race.RiverHobbit) then
+        PlayerRaceKey = 8;
+    else
+        PlayerRaceKey = 1; -- default to man race to prevent errors
+    end
+end
+
+function LoadSettings()
+    -- load the self.settings
+    -- if a value is not available, set a default value
+
+    -- load TWII settings file
+    pcall(function()
+        SettingsStrings = PatchDataLoad(Turbine.DataScope.Character, "TravelWindowIISettings");
+    end);
+
+    -- save a daily backup of settings
+    if (SettingsStrings) then
+        SettingsStrings.backupTime = "#" .. Turbine.Engine.GetGameTime();
+        local dateInfo = Turbine.Engine.GetDate();
+        PatchDataSave(Turbine.DataScope.Character, "TravelWindowIISettings_backup" .. dateInfo.DayOfWeek,
+                      SettingsStrings);
+    end
+
+    -- try importing Travel Window I settings if new settings were not found
+    local importOldSettings = false;
+    if (SettingsStrings == nil) then
+        local result;
+        importOldSettings, result = pcall(function()
+            SettingsStrings = PatchDataLoad(Turbine.DataScope.Character, "TravelWindowSettings");
+        end);
+    end
+
+    if (type(SettingsStrings) ~= "table") then
+        SettingsStrings = {};
+    end
+
+    if (not SettingsStrings.lastLoadedVersion or SettingsStrings.lastLoadedVersion == "nil") then
+        SettingsStrings.lastLoadedVersion = tostring(Plugins["Travel Window II"]:GetVersion());
+    end
+
+    if (not SettingsStrings.width or SettingsStrings.width == "nil") then
+        SettingsStrings.width = tostring(0);
+    end
+
+    if (not SettingsStrings.height or SettingsStrings.height == "nil") then
+        SettingsStrings.height = tostring(0);
+    end
+
+    if (not SettingsStrings.positionX or SettingsStrings.positionX == "nil") then
+        SettingsStrings.positionX = tostring(Turbine.UI.Display.GetWidth() * 0.75);
+    end
+
+    if (not SettingsStrings.positionY or SettingsStrings.positionY == "nil") then
+        SettingsStrings.positionY = tostring(Turbine.UI.Display.GetHeight() * 0.75);
+    end
+
+    local screenWidth = Turbine.UI.Display.GetWidth();
+    local screenHeight = Turbine.UI.Display.GetHeight();
+    if not SettingsStrings.buttonRelativeX or SettingsStrings.buttonRelativeX == "nil" then
+        if SettingsStrings.buttonPositionX and SettingsStrings.buttonPositionX ~= "nil" and
+                tonumber(SettingsStrings.buttonPositionX) < screenWidth then
+            -- not perfect, but assuming the same resolution, this will approximately convert to a relative value
+            SettingsStrings.buttonRelativeX = tonumber(SettingsStrings.buttonPositionX) / screenWidth;
+            if SettingsStrings.buttonRelativeX > 1.0 then
+                SettingsStrings.buttonRelativeX = 0.95;
+            end
+            SettingsStrings.buttonRelativeX = tostring(SettingsStrings.buttonRelativeX);
+        else
+            SettingsStrings.buttonRelativeX = "0.95";
+        end
+    end
+
+    if not SettingsStrings.buttonRelativeY or SettingsStrings.buttonRelativeY == "nil" then
+        if SettingsStrings.buttonPositionY and SettingsStrings.buttonPositionY ~= "nil" and
+                tonumber(SettingsStrings.buttonPositionY) < screenHeight then
+            -- not perfect, but assuming the same resolution, this will approximately convert to a relative value
+            SettingsStrings.buttonRelativeY = tonumber(SettingsStrings.buttonPositionY) / screenHeight;
+            if SettingsStrings.buttonRelativeY > 1.0 then
+                SettingsStrings.buttonRelativeY = 0.75;
+            end
+            SettingsStrings.buttonRelativeY = tostring(SettingsStrings.buttonRelativeY);
+        else
+            SettingsStrings.buttonRelativeY = "0.75";
+        end
+    end
+
+    if (not SettingsStrings.hideOnStart or SettingsStrings.hideOnStart == "nil") then
+        SettingsStrings.hideOnStart = tostring(0);
+    end
+
+    if (not SettingsStrings.hideOnCombat or SettingsStrings.hideOnCombat == "nil") then
+        SettingsStrings.hideOnCombat = tostring(0);
+    end
+
+    if (not SettingsStrings.pulldownTravel or SettingsStrings.pulldownTravel == "nil") then
+        SettingsStrings.pulldownTravel = tostring(0);
+    end
+
+    if (not SettingsStrings.hideOnTravel or SettingsStrings.hideOnTravel == "nil") then
+        SettingsStrings.hideOnTravel = tostring(0);
+    end
+
+    if (not SettingsStrings.ignoreEsc or SettingsStrings.ignoreEsc == "nil") then
+        SettingsStrings.ignoreEsc = tostring(0);
+    end
+
+    if (not SettingsStrings.showButton or SettingsStrings.showButton == "nil") then
+        SettingsStrings.showButton = tostring(1);
+    end
+
+    if (not SettingsStrings.mode or SettingsStrings.mode == "nil") then
+        SettingsStrings.mode = tostring(2);
+    end
+
+    if (not SettingsStrings.filters or SettingsStrings.filters == "nil") then
+        SettingsStrings.filters = tostring(0x0F);
+    end
+
+    if (not SettingsStrings.enabled or importOldSettings) then
+        SettingsStrings.enabled = {};
+    end
+
+    if ((not SettingsStrings.order) or importOldSettings) then
+        SettingsStrings.order = {};
+    end
+
+    if (not SettingsStrings.mainMaxOpacity or SettingsStrings.mainMaxOpacity == "nil") then
+        SettingsStrings.mainMaxOpacity = tostring(1);
+    end
+
+    if (not SettingsStrings.mainMinOpacity or SettingsStrings.mainMinOpacity == "nil") then
+        SettingsStrings.mainMinOpacity = tostring(0.5);
+    end
+
+    if (not SettingsStrings.toggleMaxOpacity or SettingsStrings.toggleMaxOpacity == "nil") then
+        SettingsStrings.toggleMaxOpacity = tostring(1);
+    end
+
+    if (not SettingsStrings.toggleMinOpacity or SettingsStrings.toggleMinOpacity == "nil") then
+        SettingsStrings.toggleMinOpacity = tostring(0.2);
+    end
+
+    -- convert from strings if necessary
+    if (type(SettingsStrings.width) == "string") then
+        Settings.width = tonumber(SettingsStrings.width);
+    else
+        Settings.width = SettingsStrings.width;
+    end
+
+    if (type(SettingsStrings.height) == "string") then
+        Settings.height = tonumber(SettingsStrings.height);
+    else
+        Settings.height = SettingsStrings.height;
+    end
+
+    if (type(SettingsStrings.positionX) == "string") then
+        Settings.positionX = tonumber(SettingsStrings.positionX);
+    else
+        Settings.positionX = SettingsStrings.positionX;
+    end
+
+    if (type(SettingsStrings.positionY) == "string") then
+        Settings.positionY = tonumber(SettingsStrings.positionY);
+    else
+        Settings.positionY = SettingsStrings.positionY;
+    end
+
+    if (type(SettingsStrings.buttonRelativeX) == "string") then
+        Settings.buttonRelativeX = tonumber(SettingsStrings.buttonRelativeX);
+    else
+        Settings.buttonRelativeX = SettingsStrings.buttonRelativeX;
+    end
+
+    if (type(SettingsStrings.buttonRelativeY) == "string") then
+        Settings.buttonRelativeY = tonumber(SettingsStrings.buttonRelativeY);
+    else
+        Settings.buttonRelativeY = SettingsStrings.buttonRelativeY;
+    end
+
+    if (type(SettingsStrings.hideOnStart) == "string") then
+        Settings.hideOnStart = tonumber(SettingsStrings.hideOnStart);
+    else
+        Settings.hideOnStart = SettingsStrings.hideOnStart;
+    end
+
+    if (type(SettingsStrings.hideOnCombat) == "string") then
+        Settings.hideOnCombat = tonumber(SettingsStrings.hideOnCombat);
+    else
+        Settings.hideOnCombat = SettingsStrings.hideOnCombat;
+    end
+
+    if (type(SettingsStrings.pulldownTravel) == "string") then
+        Settings.pulldownTravel = tonumber(SettingsStrings.pulldownTravel);
+    else
+        Settings.pulldownTravel = SettingsStrings.pulldownTravel;
+    end
+
+    if (type(SettingsStrings.hideOnTravel) == "string") then
+        Settings.hideOnTravel = tonumber(SettingsStrings.hideOnTravel);
+    else
+        Settings.hideOnTravel = SettingsStrings.hideOnTravel;
+    end
+
+    if (type(SettingsStrings.ignoreEsc) == "string") then
+        Settings.ignoreEsc = tonumber(SettingsStrings.ignoreEsc);
+    else
+        Settings.ignoreEsc = SettingsStrings.ignoreEsc;
+    end
+
+    if (type(SettingsStrings.showButton) == "string") then
+        Settings.showButton = tonumber(SettingsStrings.showButton);
+    else
+        Settings.showButton = SettingsStrings.showButton;
+    end
+
+    if (type(SettingsStrings.mode) == "string") then
+        Settings.mode = tonumber(SettingsStrings.mode);
+    else
+        Settings.mode = SettingsStrings.mode;
+    end
+
+    if (type(SettingsStrings.filters) == "string") then
+        Settings.filters = tonumber(SettingsStrings.filters);
+    else
+        Settings.filters = SettingsStrings.filters;
+    end
+
+    if (type(SettingsStrings.mainMaxOpacity) == "string") then
+        Settings.mainMaxOpacity = EuroNormalize(SettingsStrings.mainMaxOpacity);
+    else
+        Settings.mainMaxOpacity = SettingsStrings.mainMaxOpacity;
+    end
+
+    if (type(SettingsStrings.mainMinOpacity) == "string") then
+        Settings.mainMinOpacity = EuroNormalize(SettingsStrings.mainMinOpacity);
+    else
+        Settings.mainMinOpacity = SettingsStrings.mainMinOpacity;
+    end
+
+    if (type(SettingsStrings.toggleMaxOpacity) == "string") then
+        Settings.toggleMaxOpacity = EuroNormalize(SettingsStrings.toggleMaxOpacity);
+    else
+        Settings.toggleMaxOpacity = SettingsStrings.toggleMaxOpacity;
+    end
+
+    if (type(SettingsStrings.toggleMinOpacity) == "string") then
+        Settings.toggleMinOpacity = EuroNormalize(SettingsStrings.toggleMinOpacity);
+    else
+        Settings.toggleMinOpacity = SettingsStrings.toggleMinOpacity;
+    end
+
+    if (SettingsStrings.mapGlanVraig ~= nil) then
+        Settings.mapGlanVraig = SettingsStrings.mapGlanVraig;
+    end
+
+    Settings.lastLoadedVersion = SettingsStrings.lastLoadedVersion;
+    Settings.enabled = SettingsStrings.enabled;
+
+    local convertTableIndex = false;
+    for i, v in pairs(SettingsStrings.order) do
+        if (type(i) == "string") then
+            convertTableIndex = true;
+        end
+    end
+
+    if (convertTableIndex) then
+        OrderTableNumberIndex();
+    else
+        Settings.order = SettingsStrings.order;
+    end
+end
+
+function SaveSettings()
+
+    -- make sure to delete old settings to delete unused fields
+    SettingsStrings = {};
+    -- convert the settings to strings
+    SettingsStrings.lastLoadedVersion = tostring(Settings.lastLoadedVersion);
+    SettingsStrings.height = tostring(Settings.height);
+    SettingsStrings.width = tostring(Settings.width);
+    SettingsStrings.positionX = tostring(Settings.positionX);
+    SettingsStrings.positionY = tostring(Settings.positionY);
+    SettingsStrings.buttonRelativeX = tostring(Settings.buttonRelativeX);
+    SettingsStrings.buttonRelativeY = tostring(Settings.buttonRelativeY);
+    SettingsStrings.hideOnStart = tostring(Settings.hideOnStart);
+    SettingsStrings.hideOnCombat = tostring(Settings.hideOnCombat);
+    SettingsStrings.pulldownTravel = tostring(Settings.pulldownTravel);
+    SettingsStrings.hideOnTravel = tostring(Settings.hideOnTravel);
+    SettingsStrings.ignoreEsc = tostring(Settings.ignoreEsc);
+    SettingsStrings.showButton = tostring(Settings.showButton);
+    SettingsStrings.mode = tostring(Settings.mode);
+    SettingsStrings.filters = tostring(Settings.filters);
+    SettingsStrings.mainMaxOpacity = tostring(Settings.mainMaxOpacity);
+    SettingsStrings.mainMinOpacity = tostring(Settings.mainMinOpacity);
+    SettingsStrings.toggleMaxOpacity = tostring(Settings.toggleMaxOpacity);
+    SettingsStrings.toggleMinOpacity = tostring(Settings.toggleMinOpacity);
+    SettingsStrings.enabled = Settings.enabled;
+    SettingsStrings.mapGlanVraig = tostring(Settings.mapGlanVraig);
+
+    OrderTableStringIndex();
+
+    -- save the settings
+    PatchDataSave(Turbine.DataScope.Character, "TravelWindowIISettings", SettingsStrings);
+end
+
+function OrderTableStringIndex()
+
+    SettingsStrings.order = {};
+
+    for i, v in ipairs(Settings.order) do
+        SettingsStrings.order[tostring(i)] = v;
+    end
+end
+
+function OrderTableNumberIndex()
+
+    Settings.order = {};
+
+    for i, v in pairs(SettingsStrings.order) do
+        Settings.order[tonumber(i)] = v;
+    end
+end
+
+function CheckEnabledSettings()
+    if (PlayerAlignment == Turbine.Gameplay.Alignment.FreePeople) then
+        -- update generic travel settings
+        AddNewSettings(TravelInfo.gen);
+
+        -- update reputation travel settings
+        AddNewSettings(TravelInfo.rep);
+
+        -- update racial travel settings
+        local racialId = TravelInfo.racial.id;
+        if (Settings.enabled[racialId] == nil) then
+            Settings.enabled[racialId] = true;
+        end
+        if (TableContains(Settings.order, racialId) == false) then
+            table.insert(Settings.order, racialId);
+        end
+
+        local classSkills = TravelInfo:GetClassSkills();
+        if classSkills ~= nil then
+            AddNewSettings(classSkills);
+        end
+    else
+        -- update creep travel settings
+        AddNewSettings(TravelInfo.creep);
+    end
+end
+
+function AddNewSettings(skills)
+    for i = 1, skills:GetCount() do
+        local id = skills:IdAtIndex(i);
+        -- if the enabled setting for the skill is nil, set it to true as default
+        if (Settings.enabled[id] == nil) then
+            Settings.enabled[id] = true;
+        end
+
+        -- if the skill is not in the order list, add it
+        if (TableContains(Settings.order, id) == false) then
+            table.insert(Settings.order, id);
+        end
+    end
+end

--- a/src/SettingsMenu.lua
+++ b/src/SettingsMenu.lua
@@ -230,12 +230,20 @@ function LoadSettings()
         SettingsStrings.lastLoadedVersion = tostring(Plugins["Travel Window II"]:GetVersion());
     end
 
-    if (not SettingsStrings.width or SettingsStrings.width == "nil") then
-        SettingsStrings.width = tostring(0);
+    if (not SettingsStrings.gridCols or SettingsStrings.gridCols == "nil") then
+        SettingsStrings.gridCols = tostring(0);
     end
 
-    if (not SettingsStrings.height or SettingsStrings.height == "nil") then
-        SettingsStrings.height = tostring(0);
+    if (not SettingsStrings.gridRows or SettingsStrings.gridRows == "nil") then
+        SettingsStrings.gridRows = tostring(0);
+    end
+
+    if (not SettingsStrings.listWidth or SettingsStrings.listWidth == "nil") then
+        SettingsStrings.listWidth = tostring(0);
+    end
+
+    if (not SettingsStrings.listRows or SettingsStrings.listRows == "nil") then
+        SettingsStrings.listRows = tostring(0);
     end
 
     if (not SettingsStrings.positionX or SettingsStrings.positionX == "nil") then
@@ -274,6 +282,10 @@ function LoadSettings()
         else
             SettingsStrings.buttonRelativeY = "0.75";
         end
+    end
+
+    if (not SettingsStrings.useMinWindow or SettingsStrings.useMinWindow == "nil") then
+        SettingsStrings.useMinWindow = tostring(0);
     end
 
     if (not SettingsStrings.hideOnStart or SettingsStrings.hideOnStart == "nil") then
@@ -333,16 +345,28 @@ function LoadSettings()
     end
 
     -- convert from strings if necessary
-    if (type(SettingsStrings.width) == "string") then
-        Settings.width = tonumber(SettingsStrings.width);
+    if (type(SettingsStrings.gridCols) == "string") then
+        Settings.gridCols = tonumber(SettingsStrings.gridCols);
     else
-        Settings.width = SettingsStrings.width;
+        Settings.gridCols = SettingsStrings.gridCols;
     end
 
-    if (type(SettingsStrings.height) == "string") then
-        Settings.height = tonumber(SettingsStrings.height);
+    if (type(SettingsStrings.gridRows) == "string") then
+        Settings.gridRows = tonumber(SettingsStrings.gridRows);
     else
-        Settings.height = SettingsStrings.height;
+        Settings.gridRows = SettingsStrings.gridRows;
+    end
+
+    if (type(SettingsStrings.listWidth) == "string") then
+        Settings.listWidth = tonumber(SettingsStrings.listWidth);
+    else
+        Settings.listWidth = SettingsStrings.listWidth;
+    end
+
+    if (type(SettingsStrings.listRows) == "string") then
+        Settings.listRows = tonumber(SettingsStrings.listRows);
+    else
+        Settings.listRows = SettingsStrings.listRows;
     end
 
     if (type(SettingsStrings.positionX) == "string") then
@@ -367,6 +391,12 @@ function LoadSettings()
         Settings.buttonRelativeY = tonumber(SettingsStrings.buttonRelativeY);
     else
         Settings.buttonRelativeY = SettingsStrings.buttonRelativeY;
+    end
+
+    if (type(SettingsStrings.useMinWindow) == "string") then
+        Settings.useMinWindow = tonumber(SettingsStrings.useMinWindow);
+    else
+        Settings.useMinWindow = SettingsStrings.useMinWindow;
     end
 
     if (type(SettingsStrings.hideOnStart) == "string") then
@@ -468,12 +498,15 @@ function SaveSettings()
     SettingsStrings = {};
     -- convert the settings to strings
     SettingsStrings.lastLoadedVersion = tostring(Settings.lastLoadedVersion);
-    SettingsStrings.height = tostring(Settings.height);
-    SettingsStrings.width = tostring(Settings.width);
+    SettingsStrings.gridCols = tostring(Settings.gridCols);
+    SettingsStrings.gridRows = tostring(Settings.gridRows);
+    SettingsStrings.listWidth = tostring(Settings.listWidth);
+    SettingsStrings.listRows = tostring(Settings.listRows);
     SettingsStrings.positionX = tostring(Settings.positionX);
     SettingsStrings.positionY = tostring(Settings.positionY);
     SettingsStrings.buttonRelativeX = tostring(Settings.buttonRelativeX);
     SettingsStrings.buttonRelativeY = tostring(Settings.buttonRelativeY);
+    SettingsStrings.useMinWindow = tostring(Settings.useMinWindow);
     SettingsStrings.hideOnStart = tostring(Settings.hideOnStart);
     SettingsStrings.hideOnCombat = tostring(Settings.hideOnCombat);
     SettingsStrings.pulldownTravel = tostring(Settings.pulldownTravel);

--- a/src/SettingsMenu.lua
+++ b/src/SettingsMenu.lua
@@ -336,6 +336,10 @@ function LoadSettings()
         SettingsStrings.mainMinOpacity = tostring(0.5);
     end
 
+    if (not SettingsStrings.fadeOutSteps or SettingsStrings.fadeOutSteps == "nil") then
+        SettingsStrings.fadeOutSteps = tostring(1);
+    end
+
     if (not SettingsStrings.toggleMaxOpacity or SettingsStrings.toggleMaxOpacity == "nil") then
         SettingsStrings.toggleMaxOpacity = tostring(1);
     end
@@ -459,6 +463,12 @@ function LoadSettings()
         Settings.mainMinOpacity = SettingsStrings.mainMinOpacity;
     end
 
+    if (type(SettingsStrings.fadeOutSteps) == "string") then
+        Settings.fadeOutSteps = EuroNormalize(SettingsStrings.fadeOutSteps);
+    else
+        Settings.fadeOutSteps = SettingsStrings.fadeOutSteps;
+    end
+
     if (type(SettingsStrings.toggleMaxOpacity) == "string") then
         Settings.toggleMaxOpacity = EuroNormalize(SettingsStrings.toggleMaxOpacity);
     else
@@ -517,6 +527,7 @@ function SaveSettings()
     SettingsStrings.filters = tostring(Settings.filters);
     SettingsStrings.mainMaxOpacity = tostring(Settings.mainMaxOpacity);
     SettingsStrings.mainMinOpacity = tostring(Settings.mainMinOpacity);
+    SettingsStrings.fadeOutSteps = tostring(Settings.fadeOutSteps);
     SettingsStrings.toggleMaxOpacity = tostring(Settings.toggleMaxOpacity);
     SettingsStrings.toggleMinOpacity = tostring(Settings.toggleMinOpacity);
     SettingsStrings.enabled = Settings.enabled;

--- a/src/TravelButton.lua
+++ b/src/TravelButton.lua
@@ -11,11 +11,8 @@ import "TravelWindowII.src.utils.BitOps";
 
 TravelButton = class(Turbine.UI.Extensions.SimpleWindow);
 
-function TravelButton:Constructor(parent)
+function TravelButton:Constructor()
     Turbine.UI.Extensions.SimpleWindow.Constructor(self);
-
-    -- keep track of our parent window
-    self.mainWindow = parent;
 
     -- set defaults
     self:SetSize(32, 32);
@@ -102,16 +99,16 @@ function TravelButton:Constructor(parent)
                 local screenWidth, screenHeight = Turbine.UI.Display.GetSize();
                 Settings.buttonRelativeX = one / screenWidth;
                 Settings.buttonRelativeY = two / screenHeight;
-                self.mainWindow:UpdateSettings();
+                _G.travel:UpdateSettings();
                 hasMoved = false;
                 self:SetBackColor(Turbine.UI.Color(0, 0.5, 0.5, 0.5));
 
             else
-                if not self.mainWindow:IsVisible() then
+                if not _G.travel:IsVisible() then
                     CheckSkills(false);
-                    self.mainWindow:SetOpacity(Settings.mainMinOpacity);
+                    _G.travel:SetOpacity(Settings.mainMinOpacity);
                 end
-                self.mainWindow:SetVisible(not self.mainWindow:IsVisible());
+                _G.travel:SetVisible(not _G.travel:IsVisible());
             end
         else
             Menu:ShowMenu();

--- a/src/TravelButton.lua
+++ b/src/TravelButton.lua
@@ -19,7 +19,6 @@ function TravelButton:Constructor()
     self:SetBackground("TravelWindowII/src/resources/travel.tga");
     self:SetBackColorBlendMode(Turbine.UI.BlendMode.Multiply);
     self:SetBackColor(Turbine.UI.Color(0, 0.5, 0.5, 0.5));
-    self:SetWantsUpdates(true);
     self:SetZOrder(1);
 
     local screenWidth = Turbine.UI.Display.GetWidth();
@@ -47,23 +46,6 @@ function TravelButton:Constructor()
     local x = 0;
     local y = 0;
 
-    function TravelButton:Update(sender, args)
-
-        if (isMoving) then
-            if (not isHighlighted) then
-                if (Turbine.Engine.GetGameTime() - buttonDownTime > 0.4) then
-                    self:SetBackColor(Turbine.UI.Color(1.0, 0.5, 0.5, 0.95));
-                    isHighlighted = true;
-                    hasMoved = true;
-                else
-                    self:SetWantsUpdates(true);
-                end
-            end
-        else
-            Turbine.UI.Extensions.SimpleWindow.Update(self, args);
-        end
-    end
-
     -- go to full opacity if mouse is over
     self.MouseEnter = function(sender, args)
         self:SetOpacity(Settings.toggleMaxOpacity);
@@ -78,7 +60,6 @@ function TravelButton:Constructor()
     self.MouseDown = function(sender, args)
         if (args.Button == Turbine.UI.MouseButton.Left) then
             buttonDownTime = Turbine.Engine.GetGameTime();
-            self:SetWantsUpdates(true);
             isMoving = true;
             x = args.X;
             y = args.Y;
@@ -90,7 +71,6 @@ function TravelButton:Constructor()
         if (args.Button == Turbine.UI.MouseButton.Left) then
             isMoving = false;
             isHighlighted = false;
-            self:SetWantsUpdates(false);
 
             -- if the window moved, update the settings, but do not toggle
             -- the visibility of the button

--- a/src/TravelButton.lua
+++ b/src/TravelButton.lua
@@ -108,7 +108,7 @@ function TravelButton:Constructor(parent)
 
             else
                 if not self.mainWindow:IsVisible() then
-                    self.mainWindow:CheckSkills(false);
+                    CheckSkills(false);
                     self.mainWindow:SetOpacity(Settings.mainMinOpacity);
                 end
                 self.mainWindow:SetVisible(not self.mainWindow:IsVisible());

--- a/src/TravelButton.lua
+++ b/src/TravelButton.lua
@@ -9,10 +9,10 @@ import "TravelWindowII.src.utils.BitOps";
 --[[ This is the simple window that can be used to toggle ]] --
 --[[ the main Travel Window visible.]] --
 
-TravelButton = class(Turbine.UI.Extensions.SimpleWindow);
+TravelButton = class(Turbine.UI.Window);
 
 function TravelButton:Constructor()
-    Turbine.UI.Extensions.SimpleWindow.Constructor(self);
+    Turbine.UI.Window.Constructor(self);
 
     -- set defaults
     self:SetSize(32, 32);

--- a/src/TravelCaroTab.lua
+++ b/src/TravelCaroTab.lua
@@ -41,9 +41,6 @@ function TravelCaroTab:Constructor(toplevel)
 
     --[[  EVENT HANDLERS  ]] --
 
-    -- make sure we listen for key presses
-    self:SetWantsUpdates(true);
-
     -- check for a right mouse button event to open menu
     self.MouseClick = function(sender, args)
         if (args.Button == Turbine.UI.MouseButton.Right) then

--- a/src/TravelCaroTab.lua
+++ b/src/TravelCaroTab.lua
@@ -24,6 +24,12 @@ function TravelCaroTab:Constructor(toplevel)
     -- need top level window in order to close it
     self.parent = toplevel;
 
+    if self.parent.isMinWindow then
+        self.wPadding = 4;
+    else
+        self.wPadding = 0;
+    end
+
     -- this label is used to catch wheel moves
     self.scrollLabel = Turbine.UI.Label();
     self.scrollLabel:SetSize(180, 155);
@@ -210,23 +216,23 @@ function TravelCaroTab:SetSize(width, height)
     -- adjust the size and location of the 5 quickslots
     self.quickslots[1]:SetStretchMode(1);
     self.quickslots[1]:SetSize(22, 22);
-    self.quickslots[1]:SetPosition(self:GetWidth() / 2 - 67, (self:GetHeight() - offset) / 2);
+    self.quickslots[1]:SetPosition(self:GetWidth() / 2 - 71 + self.wPadding, (self:GetHeight() - offset) / 2);
 
     self.quickslots[2]:SetStretchMode(1);
     self.quickslots[2]:SetSize(28, 28);
-    self.quickslots[2]:SetPosition(self:GetWidth() / 2 - 45, (self:GetHeight() - offset) / 2 + 3);
+    self.quickslots[2]:SetPosition(self:GetWidth() / 2 - 49 + self.wPadding, (self:GetHeight() - offset) / 2 + 3);
 
     self.quickslots[3]:SetStretchMode(1); -- makes fuzzy but keeps lack of opacity consistent with other icons showing
     self.quickslots[3]:SetSize(36, 36);
-    self.quickslots[3]:SetPosition(self:GetWidth() / 2 - 18, (self:GetHeight() - offset) / 2 + 5);
+    self.quickslots[3]:SetPosition(self:GetWidth() / 2 - 22 + self.wPadding, (self:GetHeight() - offset) / 2 + 5);
 
     self.quickslots[4]:SetStretchMode(1);
     self.quickslots[4]:SetSize(28, 28);
-    self.quickslots[4]:SetPosition(self:GetWidth() / 2 + 17, (self:GetHeight() - offset) / 2 + 3);
+    self.quickslots[4]:SetPosition(self:GetWidth() / 2 + 13 + self.wPadding, (self:GetHeight() - offset) / 2 + 3);
 
     self.quickslots[5]:SetStretchMode(1);
     self.quickslots[5]:SetSize(22, 22);
-    self.quickslots[5]:SetPosition(self:GetWidth() / 2 + 45, (self:GetHeight() - offset) / 2);
+    self.quickslots[5]:SetPosition(self:GetWidth() / 2 + 40 + self.wPadding, (self:GetHeight() - offset) / 2);
 end
 
 function TravelCaroTab:SetOpacityItems(value)

--- a/src/TravelCaroTab.lua
+++ b/src/TravelCaroTab.lua
@@ -219,7 +219,6 @@ function TravelCaroTab:SetSize(width, height)
     self.quickslots[2]:SetSize(28, 28);
     self.quickslots[2]:SetPosition(self:GetWidth() / 2 - 49 + self.wPadding, (self:GetHeight() - offset) / 2 + 3);
 
-    self.quickslots[3]:SetStretchMode(1); -- makes fuzzy but keeps lack of opacity consistent with other icons showing
     self.quickslots[3]:SetSize(36, 36);
     self.quickslots[3]:SetPosition(self:GetWidth() / 2 - 22 + self.wPadding, (self:GetHeight() - offset) / 2 + 5);
 
@@ -233,6 +232,8 @@ function TravelCaroTab:SetSize(width, height)
 end
 
 function TravelCaroTab:SetOpacityItems(value)
+    -- quickslots in stretch mode do not get updated opacity from
+    -- the parent; update them here
     for i = 1, #self.quickslots do
         self.quickslots[i]:SetOpacity(value);
     end

--- a/src/TravelCaroTab.lua
+++ b/src/TravelCaroTab.lua
@@ -205,27 +205,32 @@ end
 function TravelCaroTab:SetSize(width, height)
 
     Turbine.UI.Control.SetSize(self, width, height);
+    local offset = 40;
 
     -- adjust the size and location of the 5 quickslots
     self.quickslots[1]:SetStretchMode(1);
     self.quickslots[1]:SetSize(22, 22);
-    self.quickslots[1]:SetPosition(self:GetWidth() / 2 - 67, (self:GetHeight() - 20) / 2);
+    self.quickslots[1]:SetPosition(self:GetWidth() / 2 - 67, (self:GetHeight() - offset) / 2);
 
     self.quickslots[2]:SetStretchMode(1);
     self.quickslots[2]:SetSize(28, 28);
-    self.quickslots[2]:SetPosition(self:GetWidth() / 2 - 45, (self:GetHeight() - 20) / 2 + 3);
+    self.quickslots[2]:SetPosition(self:GetWidth() / 2 - 45, (self:GetHeight() - offset) / 2 + 3);
 
     self.quickslots[3]:SetStretchMode(1); -- makes fuzzy but keeps lack of opacity consistent with other icons showing
     self.quickslots[3]:SetSize(36, 36);
-    self.quickslots[3]:SetPosition(self:GetWidth() / 2 - 18, (self:GetHeight() - 20) / 2 + 5);
+    self.quickslots[3]:SetPosition(self:GetWidth() / 2 - 18, (self:GetHeight() - offset) / 2 + 5);
 
     self.quickslots[4]:SetStretchMode(1);
     self.quickslots[4]:SetSize(28, 28);
-    self.quickslots[4]:SetPosition(self:GetWidth() / 2 + 17, (self:GetHeight() - 20) / 2 + 3);
+    self.quickslots[4]:SetPosition(self:GetWidth() / 2 + 17, (self:GetHeight() - offset) / 2 + 3);
 
     self.quickslots[5]:SetStretchMode(1);
     self.quickslots[5]:SetSize(22, 22);
-    self.quickslots[5]:SetPosition(self:GetWidth() / 2 + 45, (self:GetHeight() - 20) / 2);
+    self.quickslots[5]:SetPosition(self:GetWidth() / 2 + 45, (self:GetHeight() - offset) / 2);
+end
 
-    Turbine.UI.Control.SetOpacity(self, 1);
+function TravelCaroTab:SetOpacityItems(value)
+    for i = 1, #self.quickslots do
+        self.quickslots[i]:SetOpacity(value);
+    end
 end

--- a/src/TravelGridTab.lua
+++ b/src/TravelGridTab.lua
@@ -82,9 +82,6 @@ function TravelGridTab:Constructor(toplevel)
 
     --[[  EVENT HANDLERS  ]] --
 
-    -- make sure we check for updates
-    self:SetWantsUpdates(true);
-
     -- check for a right mouse button event to open menu
     self.MouseClick = function(sender, args)
         if (args.Button == Turbine.UI.MouseButton.Right) then

--- a/src/TravelListTab.lua
+++ b/src/TravelListTab.lua
@@ -22,6 +22,7 @@ function TravelListTab:Constructor(toplevel)
     TravelGridTab.Constructor(self);
 
     self.itemHeight = 22;
+    self.scrollChunk = self.itemHeight;
 
     -- set up the scrollbar for the list
     self.myScrollBar = Turbine.UI.Lotro.ScrollBar();
@@ -127,9 +128,26 @@ function TravelListTab:AddItem(shortcut)
     self.row = self.row + 1;
 end
 
-function TravelListTab:UpdateBounds(numOfShortcuts)
+function TravelListTab:FitListPixels(width, height)
+    local rowHeight = self.itemHeight;
+    local minHeight = self.parent.hPadding + rowHeight * 6 + 3;
+    local dy = height % rowHeight;
+    if dy < rowHeight / 2 then
+        height = height - dy;
+    else
+        height = height + (rowHeight - dy);
+    end
+    height = height + 3;
+    if height < minHeight then
+        height = minHeight;
+    end
+    return width, height;
+end
+
+function TravelListTab:UpdateBounds()
     -- set the maximum value of the scrollbar
     -- based on the number of rows in the subwindow
+    local numOfShortcuts = #self.selected;
     self.maxScroll = numOfShortcuts * 22 - self:GetHeight();
     if self.maxScroll < 0 then
         -- the maxScroll cannot be less than one

--- a/src/TravelPulldownTab.lua
+++ b/src/TravelPulldownTab.lua
@@ -20,6 +20,12 @@ function TravelPulldownTab:Constructor(toplevel)
     -- need top level window in order to close it
     self.parent = toplevel;
 
+    if self.parent.isMinWindow then
+        self.wPadding = 3;
+    else
+        self.wPadding = 0;
+    end
+
     -- this label is used to catch wheel moves
     self.scrollLabel = Turbine.UI.Label();
     self.scrollLabel:SetPosition(0, 0);
@@ -27,7 +33,7 @@ function TravelPulldownTab:Constructor(toplevel)
 
     -- the pulldown box
     self.pulldown = TravelWindowII.src.OrendarUIMods.ComboBox(self);
-    self.pulldown:SetPosition(48, 5);
+    self.pulldown:SetPosition(43 + self.wPadding, 5);
     self.pulldown:SetParent(self);
     self.pulldown:SetVisible(true);
     self.pulldown:SetTravelOnSelect(Settings.pulldownTravel);
@@ -35,7 +41,7 @@ function TravelPulldownTab:Constructor(toplevel)
     -- the quickslot for the shortcut
     self.quickslot = Turbine.UI.Lotro.Quickslot();
     self.quickslot:SetSize(36, 36);
-    self.quickslot:SetPosition(5, 1);
+    self.quickslot:SetPosition(self.wPadding, 1);
     self.quickslot:SetZOrder(98);
     self.quickslot:SetUseOnRightClick(false);
     self.quickslot:SetParent(self);
@@ -136,8 +142,6 @@ function TravelPulldownTab:SetSize(width, height)
     -- set the size of the labels
     self.scrollLabel:SetSize(self:GetWidth(), self:GetHeight());
     self.pulldown:SetSize(self:GetWidth() - 58, 30);
-
-    Turbine.UI.Control.SetOpacity(self, 1);
 end
 
 -- function to close the pulldown if necessary

--- a/src/TravelPulldownTab.lua
+++ b/src/TravelPulldownTab.lua
@@ -141,7 +141,7 @@ function TravelPulldownTab:SetSize(width, height)
 
     -- set the size of the labels
     self.scrollLabel:SetSize(self:GetWidth(), self:GetHeight());
-    self.pulldown:SetSize(self:GetWidth() - 58, 30);
+    self.pulldown:SetSize(self:GetWidth() - 58 + self.wPadding * 2, 30);
 end
 
 -- function to close the pulldown if necessary

--- a/src/TravelPulldownTab.lua
+++ b/src/TravelPulldownTab.lua
@@ -141,6 +141,11 @@ function TravelPulldownTab:SetSize(width, height)
     self.pulldown:SetSize(self:GetWidth() - 58 + self.wPadding * 2, 30);
 end
 
+function TravelPulldownTab:SetOpacity(value)
+    Turbine.UI.Control.SetOpacity(self, value);
+    self.pulldown.dropDownWindow:SetOpacity(value);
+end
+
 -- function to close the pulldown if necessary
 function TravelPulldownTab:ClosePulldown()
     self.pulldown:CloseDropDown()

--- a/src/TravelPulldownTab.lua
+++ b/src/TravelPulldownTab.lua
@@ -22,14 +22,12 @@ function TravelPulldownTab:Constructor(toplevel)
 
     -- this label is used to catch wheel moves
     self.scrollLabel = Turbine.UI.Label();
-    self.scrollLabel:SetSize(180, 155);
     self.scrollLabel:SetPosition(0, 0);
     self.scrollLabel:SetParent(self);
 
     -- the pulldown box
     self.pulldown = TravelWindowII.src.OrendarUIMods.ComboBox(self);
-    self.pulldown:SetPosition(10, 20);
-    self.pulldown:SetSize(self:GetWidth() - 20, 30);
+    self.pulldown:SetPosition(48, 5);
     self.pulldown:SetParent(self);
     self.pulldown:SetVisible(true);
     self.pulldown:SetTravelOnSelect(Settings.pulldownTravel);
@@ -37,6 +35,7 @@ function TravelPulldownTab:Constructor(toplevel)
     -- the quickslot for the shortcut
     self.quickslot = Turbine.UI.Lotro.Quickslot();
     self.quickslot:SetSize(36, 36);
+    self.quickslot:SetPosition(5, 1);
     self.quickslot:SetZOrder(98);
     self.quickslot:SetUseOnRightClick(false);
     self.quickslot:SetParent(self);
@@ -135,10 +134,8 @@ function TravelPulldownTab:SetSize(width, height)
     Turbine.UI.Control.SetSize(self, width, height);
 
     -- set the size of the labels
-    self.pulldown:SetSize(self:GetWidth() - 20, 30);
     self.scrollLabel:SetSize(self:GetWidth(), self:GetHeight());
-    -- center the quickslot
-    self.quickslot:SetPosition(self:GetWidth() / 2.0 - 18, 55);
+    self.pulldown:SetSize(self:GetWidth() - 58, 30);
 
     Turbine.UI.Control.SetOpacity(self, 1);
 end

--- a/src/TravelPulldownTab.lua
+++ b/src/TravelPulldownTab.lua
@@ -49,9 +49,6 @@ function TravelPulldownTab:Constructor(toplevel)
 
     --[[  EVENT HANDLERS  ]] --
 
-    -- make sure we listen for key presses
-    self:SetWantsUpdates(true);
-
     -- check for a right mouse button event to open menu
     self.MouseClick = function(sender, args)
         if (args.Button == Turbine.UI.MouseButton.Right) then

--- a/src/TravelWindow.lua
+++ b/src/TravelWindow.lua
@@ -203,6 +203,17 @@ function TravelWindow:Constructor(useMinWindow)
     end
     AddCallback(player, "InCombatChanged", IncombatChangedHandler);
 
+    self.Update = function(sender, args)
+        -- handle opacity fade out
+        local stepSize = (Settings.mainMaxOpacity - Settings.mainMinOpacity) / Settings.fadeOutSteps;
+        local opacity = self:GetOpacity() - stepSize;
+        if opacity < Settings.mainMinOpacity then
+            opacity = Settings.mainMinOpacity
+            self:SetWantsUpdates(false);
+        end
+        self:SetOpacity(opacity);
+    end
+
     -- if the visible status of the window changes, close the pulldown tab
     self.VisibleChanged = function(sender, args)
         if (self:IsVisible() == false) then
@@ -222,7 +233,7 @@ function TravelWindow:Constructor(useMinWindow)
 
     -- go to full opacity if mouse is over
     self.MouseEnter = function(sender, args)
-        self:SetOpacity(Settings.mainMaxOpacity);
+        self:SetMaxOpacity();
     end
 
     -- go to low opacity when mouse is not over
@@ -231,7 +242,7 @@ function TravelWindow:Constructor(useMinWindow)
         local winX, winY = self:GetSize();
 
         if not self.isMouseDown then
-            self:SetOpacity(Settings.mainMinOpacity);
+            self:FadeOut();
         end
     end
 
@@ -278,7 +289,7 @@ function TravelWindow:Constructor(useMinWindow)
         local winX, winY = self:GetSize();
         local outsideWindow = mX < 1 or mY < 1 or mX > winX - 1 or mY > winY - 1;
         if outsideWindow then
-            self:SetOpacity(Settings.mainMinOpacity);
+            self:FadeOut();
         end
 
         self.isMouseDown = false;
@@ -314,6 +325,15 @@ function TravelWindow:Constructor(useMinWindow)
     elseif Settings.mode == 2 then
         self:SetSize(self.GridTab:FitToPixels(self:GetSize()));
     end
+end
+
+function TravelWindow:SetMaxOpacity()
+    self:SetOpacity(Settings.mainMaxOpacity);
+    self:SetWantsUpdates(false);
+end
+
+function TravelWindow:FadeOut()
+    self:SetWantsUpdates(true);
 end
 
 function TravelWindow:SetItems()
@@ -541,6 +561,7 @@ function TravelWindow:ResetSettings()
     Settings.order = {};
     Settings.mainMaxOpacity = 1;
     Settings.mainMinOpacity = 0.5;
+    Settings.fadeOutSteps = 1;
     Settings.toggleMaxOpacity = 1;
     Settings.toggleMinOpacity = 0.5;
 

--- a/src/TravelWindow.lua
+++ b/src/TravelWindow.lua
@@ -31,10 +31,10 @@ function TravelWindow:Constructor(useMinWindow)
     self.isResizing = false;
     self.isMinWindow = useMinWindow == 1;
     if self.isMinWindow then
-        self.wPos = 3;
+        self.wPos = -1;
         self.hPos = 20;
-        self.wPadding = 7;
-        self.hPadding = 25;
+        self.wPadding = -1;
+        self.hPadding = 20;
         self.resizeLabelSize = 13;
         self.backColor = Turbine.UI.Color(1, 0, 0, 0);
     else

--- a/src/TravelWindow.lua
+++ b/src/TravelWindow.lua
@@ -122,8 +122,6 @@ function TravelWindow:Constructor(useMinWindow)
 
     --[[ Event Handlers ]] --
 
-    -- make sure we listen for updates
-    self:SetWantsUpdates(true);
     self:SetWantsKeyEvents(true);
 
     -- check if our position has changed, and save the settings if so

--- a/src/TravelWindow.lua
+++ b/src/TravelWindow.lua
@@ -238,13 +238,12 @@ function TravelWindow:Constructor(useMinWindow)
 
     -- go to low opacity when mouse is not over
     self.MouseLeave = function(sender, args)
-        local mX, mY = self:GetMousePosition();
-        local winX, winY = self:GetSize();
-
         if not self.isMouseDown then
             self:FadeOut();
         end
     end
+    self.PullTab.pulldown.dropDownWindow.MouseEnter = self.MouseEnter;
+    self.PullTab.pulldown.dropDownWindow.MouseLeave = self.MouseLeave;
 
     self.MouseDown = function(sender, args)
         self.isMouseDown = true;
@@ -506,9 +505,8 @@ end
 
 function TravelWindow:SetOpacity(value)
     Turbine.UI.Window.SetOpacity(self, value);
-    -- quickslots in stretch mode do not get updated opacity from
-    -- the parent; update them here
     self.CaroTab:SetOpacityItems(value);
+    self.PullTab:SetOpacity(value);
 end
 
 function TravelWindow:UpdateSettings()

--- a/src/extensions/DPanel.lua
+++ b/src/extensions/DPanel.lua
@@ -1,7 +1,6 @@
 import "Turbine";
 import "Turbine.Gameplay";
 import "Turbine.UI";
-import "Turbine.UI.Extensions";
 import "Turbine.UI.Lotro";
 import "TravelWindowII.src.extensions";
 


### PR DESCRIPTION
Effectively, there are two skins now. The original silver window skin and a slim mostly windowless skin. I also changed the grid to snap to the next column and/or row size.
To make the skin-switching work well, I had to shift around a significant amount of code. There was also application level startup functionality embedded within TravelWindow that I moved into main.
I have been testing it for the past week and have not noticed any issues. Empty and existing settings also seem to update seamlessly.
To me it is really visually appealing, let me know what you think!