### PR TITLE
Pulldown tab bug fixes

### DIFF
--- a/src/OptionsPanel.lua
+++ b/src/OptionsPanel.lua
@@ -329,7 +329,7 @@ function OptionsPanel:AddGeneralItems()
     self.mainFadeScrollBar:SetSize(450, 10);
     self.mainFadeScrollBar:SetPosition(20, self:NextY(25));
     self.mainFadeScrollBar:SetMinimum(1);
-    self.mainFadeScrollBar:SetMaximum(51);
+    self.mainFadeScrollBar:SetMaximum(151);
     self.mainFadeScrollBar:SetValue(Settings.fadeOutSteps);
     self.mainFadeScrollBar:SetParent(self.GeneralTab);
 

--- a/src/OrendarUIMods/ComboBox.lua
+++ b/src/OrendarUIMods/ComboBox.lua
@@ -18,17 +18,18 @@ ComboBox.BlackColor = Turbine.UI.Color(1, 0, 0, 0);
 function ComboBox:Constructor(toplevel)
     Turbine.UI.Control.Constructor(self);
 
+    self.itemHeight = 20;
     self:SetBackColor(ComboBox.DisabledColor);
     self.quickslots = {};
     self.labels = {};
-    self.hoverIndex = 0;
 
     self.topLevelWindow = toplevel;
 
     -- state
     self.dropped = false;
     self.selection = -1;
-    self.travelOnSelect = 0;
+    self.hoverIndex = 0;
+    self.hoverScroll = false;
 
     -- text label
     self.label = TravelWindowII.src.extensions.DLabel();
@@ -59,8 +60,11 @@ function ComboBox:Constructor(toplevel)
     -- list scroll bar        
     self.scrollBar = Turbine.UI.Lotro.ScrollBar();
     self.scrollBar:SetOrientation(Turbine.UI.Orientation.Vertical);
-    self.scrollBar:SetParent(self.dropDownWindow);
     self.scrollBar:SetBackColor(ComboBox.BlackColor);
+    self.scrollBar:SetParent(self.dropDownWindow);
+    self.scrollBar:SetLargeChange(self.itemHeight);
+    self.scrollBar:SetSmallChange(self.itemHeight);
+    self.scrollBar:SetVisible(false);
 
     -- list to contain the drop down items
     self.listBox = Turbine.UI.Control();
@@ -76,18 +80,25 @@ function ComboBox:Constructor(toplevel)
     end
 
     self.FocusLost = function(sender, args)
-        if self.dropped then
-            if self.hoverIndex > 0 then
-                local msArgs = { Button = Turbine.UI.MouseButton.None };
-                self.labels[self.hoverIndex]:MouseClick(sender, args)
-            else
-                self:CloseDropDown()
-            end
+        if self.dropped and self.hoverIndex == 0 and not self.hoverScroll then
+            self:CloseDropDown()
         end
     end
-end
 
-function ComboBox:SetTravelOnSelect(value) self.travelOnSelect = value; end
+    -- FIXME: The window should remain opaque while grabbing the thumb button.
+    --        However, when the thumb button is grabbed, leaving the scrollbar
+    --        triggers a MouseLeave event on the dropDownWindow, which triggers a FadeOut().
+    --        Further, ScrollBar.MouseDown/Up do not work when grabbing the thumb button.
+    self.scrollBar.MouseEnter = function(sender, args)
+        self.hoverScroll = true;
+    end
+    self.scrollBar.MouseLeave = function(sender, args)
+        self.hoverScroll = false;
+    end
+    self.scrollBar.ValueChanged = function(sender, args)
+        self:UpdateSubWindow();
+    end
+end
 
 function ComboBox:MouseEnter(args)
     if (not self:IsEnabled()) then return; end
@@ -149,93 +160,78 @@ end
 function ComboBox:ClearItems()
     self.labels = {};
     self.quickslots = {};
+    self.listBox:GetControls():Clear();
     self.label:SetText("");
 end
 
-function ComboBox:AddItem(shortcut, index, value)
+function ComboBox:AddItem(shortcut, value)
     local width, height = self:GetSize();
 
-    self.quickslots[index] = Turbine.UI.Lotro.Quickslot();
-    self.quickslots[index]:SetSize(width, 20);
-    self.quickslots[index]:SetPosition(0, ((index - 1) * (20)));
-    self.quickslots[index]:SetZOrder(90);
-    self.quickslots[index]:SetOpacity(1);
-    self.quickslots[index]:SetUseOnRightClick(false);
-    self.quickslots[index]:SetParent(self.listBox);
-    self.quickslots[index]:SetShortcut(shortcut);
+    local index = #self.labels + 1;
+    local label = TravelWindowII.src.extensions.DLabel();
+    label:SetSize(width, self.itemHeight);
+    label:SetPosition(0, ((index - 1) * (self.itemHeight)));
+    label:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleCenter);
+    label:SetForeColor(ComboBox.ItemColor);
+    label:SetFont(Turbine.UI.Lotro.Font.TrajanPro14);
+    label:SetOutlineColor(ComboBox.HighlightColor);
+    label:SetBackColor(Turbine.UI.Color(0.87, 0, 0, 0));
+    label:SetText(shortcut:GetSkillLabel());
+    label:SetMouseVisible(Settings.pulldownTravel == 0);
+    label:SetParent(self.listBox);
 
-    -- self.labels[index] = Turbine.UI.Label();
-    self.labels[index] = TravelWindowII.src.extensions.DLabel();
-    self.labels[index]:SetSize(width, 20);
-    self.labels[index]:SetPosition(0, ((index - 1) * (20)));
-    self.labels[index]:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleCenter);
-    self.labels[index]:SetForeColor(ComboBox.ItemColor);
-    self.labels[index]:SetFont(Turbine.UI.Lotro.Font.TrajanPro14);
-    self.labels[index]:SetOutlineColor(ComboBox.HighlightColor);
-    self.labels[index]:SetBackColor(Turbine.UI.Color(0.87, 0, 0, 0));
-    self.labels[index]:SetText(shortcut:GetSkillLabel());
-    self.labels[index]:SetZOrder(100);
-    self.labels[index]:SetMouseVisible(self.travelOnSelect == 0);
-    self.labels[index]:SetParent(self.listBox);
+    label.MouseWheel = function(sender, args)
+        self:DoScroll(sender, args);
+    end
 
-    self.quickslots[index]:SetAllowDrop(false);
-    self.quickslots[index]:SetVisible(true);
-
-    self.labels[index].MouseEnter = function(sender, args)
-        sender:SetFontStyle(Turbine.UI.FontStyle.Outline);
-        sender:SetForeColor(ComboBox.ItemColor);
-        sender:SetText(sender:GetText());
+    label.MouseEnter = function(sender, args)
+        self.labels[index]:SetFontStyle(Turbine.UI.FontStyle.Outline);
+        self.labels[index]:SetForeColor(ComboBox.ItemColor);
         self.hoverIndex = index;
     end
 
-    self.labels[index].MouseLeave = function(sender, args)
-        sender:SetFontStyle(Turbine.UI.FontStyle.None);
+    label.MouseLeave = function(sender, args)
+        self.labels[index]:SetFontStyle(Turbine.UI.FontStyle.None);
         if (index == self.selection) then
-            sender:SetForeColor(ComboBox.SelectionColor);
+            self.labels[index]:SetForeColor(ComboBox.SelectionColor);
+        else
+            self.labels[index]:SetForeColor(ComboBox.ItemColor);
         end
-        sender:SetText(sender:GetText());
         self.hoverIndex = 0;
     end
 
-    self.labels[index].MouseClick = function(sender, args)
+    label.MouseClick = function(sender, args)
         if (args.Button == Turbine.UI.MouseButton.Left) then
             self:ItemSelected(index);
             self:FireEvent();
-            if (self.travelOnSelect == 1 and Settings.hideOnTravel == 1) then
+            if (Settings.pulldownTravel == 1 and Settings.hideOnTravel == 1) then
                 self.topLevelWindow:SetVisible(false);
             end
         end
     end
 
-    self.labels[index].MouseWheel = function(sender, args)
-        self:DoScroll(sender, args);
-    end
-    self.quickslots[index].MouseWheel = function(sender, args)
-        self:DoScroll(sender, args);
+    if Settings.pulldownTravel == 1 then
+        label:SetZOrder(100);
+        local quickslot = Turbine.UI.Lotro.Quickslot();
+        quickslot:SetZOrder(90);
+        quickslot:SetSize(width, self.itemHeight);
+        quickslot:SetPosition(0, ((index - 1) * (self.itemHeight)));
+        quickslot:SetOpacity(0);
+        quickslot:SetUseOnRightClick(false);
+        quickslot:SetParent(self.listBox);
+        quickslot:SetShortcut(shortcut);
+        quickslot:SetAllowDrop(false);
+        quickslot:SetVisible(true);
+
+        quickslot.MouseWheel = label.MouseWheel;
+        quickslot.MouseEnter = label.MouseEnter;
+        quickslot.MouseLeave = label.MouseLeave;
+        quickslot.MouseClick = label.MouseClick;
+        self.quickslots[index] = quickslot;
     end
 
-    self.quickslots[index].MouseEnter = function(sender, args)
-        self.labels[index]:SetFontStyle(Turbine.UI.FontStyle.Outline);
-        self.labels[index]:SetForeColor(ComboBox.ItemColor);
-        self.labels[index]:SetText(self.labels[index]:GetText());
-    end
-    self.quickslots[index].MouseLeave = function(sender, args)
-        self.labels[index]:SetFontStyle(Turbine.UI.FontStyle.None);
-        if (index == self.selection) then
-            self.labels[index]:SetForeColor(ComboBox.SelectionColor);
-        end
-        self.labels[index]:SetText(self.labels[index]:GetText());
-    end
-
-    self.quickslots[index].MouseClick = function(sender, args)
-        if (args.Button == Turbine.UI.MouseButton.Left) then
-            self:ItemSelected(index);
-            self:FireEvent();
-            self.topLevelWindow:SetVisible(false);
-        end
-    end
-
-    self.labels[index]:SetIndex(value);
+    label:SetIndex(value);
+    self.labels[index] = label;
 end
 
 function ComboBox:RemoveItem(value)
@@ -339,9 +335,11 @@ function ComboBox:Layout()
     self.dropDownWindow:SetSize(width, listHeight + 4);
     self.scrollBar:SetPosition(width - 12, 2);
 
+    for i = 1, #self.labels, 1 do
+        self.labels[i]:SetSize(width, self.itemHeight);
+    end
     for i = 1, #self.quickslots, 1 do
-        self.quickslots[i]:SetSize(width, 20);
-        self.labels[i]:SetSize(width, 20);
+        self.quickslots[i]:SetSize(width, self.itemHeight);
     end
 end
 
@@ -380,8 +378,7 @@ function ComboBox:ShowDropDown()
         -- scrollbar
         self.scrollBar:SetSize(10, listHeight);
         self.scrollBar:SetPosition(width - 12, 2);
-        self.scrollBar:SetMinimum(0);
-        self.scrollBar:SetMaximum(itemCount * 20 - 200);
+        self.scrollBar:SetMaximum(itemCount * self.itemHeight - listHeight);
 
         -- position
         local parent = self:GetParent();
@@ -397,10 +394,6 @@ function ComboBox:ShowDropDown()
         self.dropDownWindow:SetPosition(screenX, screenY + cbHeight + 3);
 
         self.dropDownWindow:SetVisible(true);
-
-        self.scrollBar.ValueChanged = function(sender, args)
-            self:UpdateSubWindow();
-        end
     end
 end
 
@@ -417,7 +410,7 @@ end
 function ComboBox:DoScroll(sender, args)
 
     -- calculate how far to move the scrollbar
-    local newValue = self.scrollBar:GetValue() - args.Direction * 20;
+    local newValue = self.scrollBar:GetValue() - args.Direction * self.itemHeight;
 
     -- make sure the value does not go below zero
     if (newValue < 0) then newValue = 0; end
@@ -433,14 +426,10 @@ function ComboBox:DoScroll(sender, args)
 end
 
 function ComboBox:UpdateSubWindow()
-    -- loop through all the quickslots
+    for i = 1, #self.labels, 1 do
+        self.labels[i]:SetTop((i - 1) * self.itemHeight - self.scrollBar:GetValue());
+    end
     for i = 1, #self.quickslots, 1 do
-        -- get the number of rows
-        local row = math.ceil(i / 1);
-
-        -- set the top position of the quickslots based on row
-        -- number and the value of the scrollbar
-        self.quickslots[i]:SetTop((row - 1) * 20 - self.scrollBar:GetValue());
-        self.labels[i]:SetTop((row - 1) * 20 - self.scrollBar:GetValue());
+        self.quickslots[i]:SetTop((i - 1) * self.itemHeight - self.scrollBar:GetValue());
     end
 end

--- a/src/SettingsMenu.lua
+++ b/src/SettingsMenu.lua
@@ -287,29 +287,29 @@ function SetSettings(settingsArg, importOldSettings)
     -- fixup deprecated buttonPositionX
     local buttonRelativeX = Settings.buttonRelativeX;
     if settingsArg.buttonPositionX and settingsArg.buttonPositionX ~= "nil" then
-        settingsArg.buttonPositionX = nil;
         local screenWidth = Turbine.UI.Display.GetWidth();
         if tonumber(settingsArg.buttonPositionX) < screenWidth then
             -- not perfect, but assuming the same resolution, this will approximately convert to a relative value
             buttonRelativeX = tonumber(settingsArg.buttonPositionX) / screenWidth;
-            if settingsArg.buttonRelativeX > 1.0 then
+            if buttonRelativeX > 1.0 then
                 buttonRelativeX = Settings.buttonRelativeX;
             end
         end
+        settingsArg.buttonPositionX = nil;
     end
 
     -- fixup deprecated buttonPositionY
     local buttonRelativeY = Settings.buttonRelativeY;
     if settingsArg.buttonPositionY and settingsArg.buttonPositionY ~= "nil" then
-        settingsArg.buttonPositionY = nil;
         local screenHeight = Turbine.UI.Display.GetHeight();
         if tonumber(settingsArg.buttonPositionY) < screenHeight then
             -- not perfect, but assuming the same resolution, this will approximately convert to a relative value
             buttonRelativeY = tonumber(settingsArg.buttonPositionY) / screenHeight;
-            if settingsArg.buttonRelativeY > 1.0 then
+            if buttonRelativeY > 1.0 then
                 buttonRelativeY = Settings.buttonRelativeY;
             end
         end
+        settingsArg.buttonPositionY = nil;
     end
 
     InitNumberSetting(settingsArg, "gridCols");

--- a/src/TravelGridTab.lua
+++ b/src/TravelGridTab.lua
@@ -44,6 +44,8 @@ function TravelGridTab:Constructor(toplevel)
     self.myScrollBar = Turbine.UI.Lotro.ScrollBar();
     self.myScrollBar:SetOrientation(Turbine.UI.Orientation.Vertical);
     self.myScrollBar:SetMinimum(0);
+    self.myScrollBar:SetLargeChange(self.scrollChunk);
+    self.myScrollBar:SetSmallChange(self.scrollChunk);
     self.myScrollBar:SetVisible(false);
 
     self.myScrollBar.MouseClick = function(sender, args)
@@ -157,8 +159,6 @@ function TravelGridTab:SetItems()
         self.myScrollBar:SetParent(self.SubWindow);
         self.myScrollBar:SetSize(10, self:GetHeight() - 10);
         self.myScrollBar:SetPosition(self:GetWidth() - 10, 0);
-        self.myScrollBar:SetSmallChange(self.scrollChunk);
-        self.myScrollBar:SetLargeChange(self.scrollChunk);
         self.myScrollBar:SetMaximum(self.maxScroll);
         self.myScrollBar:SetVisible(self.maxScroll > 0);
         self.myLabel:SetParent(self.SubWindow);
@@ -170,8 +170,6 @@ function TravelGridTab:SetItems()
         self.SubWindow:SetSize(self:GetWidth(), self:GetHeight());
         self.myScrollBar:SetSize(10, self:GetHeight() - 10);
         self.myScrollBar:SetPosition(self:GetWidth() - 10, 0);
-        self.myScrollBar:SetSmallChange(self.scrollChunk);
-        self.myScrollBar:SetLargeChange(self.scrollChunk);
         self.myScrollBar:SetMaximum(self.maxScroll);
         self.myScrollBar:SetVisible(self.maxScroll > 0);
         self.myLabel:SetSize(self:GetWidth() - 10, self:GetHeight());

--- a/src/TravelPulldownTab.lua
+++ b/src/TravelPulldownTab.lua
@@ -26,17 +26,18 @@ function TravelPulldownTab:Constructor(toplevel)
         self.wPadding = 0;
     end
 
+    self.travelOnSelect = 0;
+
     -- this label is used to catch wheel moves
     self.scrollLabel = Turbine.UI.Label();
     self.scrollLabel:SetPosition(0, 0);
     self.scrollLabel:SetParent(self);
 
     -- the pulldown box
-    self.pulldown = TravelWindowII.src.OrendarUIMods.ComboBox(self);
+    self.pulldown = TravelWindowII.src.OrendarUIMods.ComboBox(toplevel);
     self.pulldown:SetPosition(43 + self.wPadding, 5);
     self.pulldown:SetParent(self);
     self.pulldown:SetVisible(true);
-    self.pulldown:SetTravelOnSelect(Settings.pulldownTravel);
 
     -- the quickslot for the shortcut
     self.quickslot = Turbine.UI.Lotro.Quickslot();
@@ -107,24 +108,29 @@ end
 
 function TravelPulldownTab:SetItems()
 
-    if self.tabId ~= self.parent.MainPanel.selectedPage or not(self.parent.dirty) then
+    if self.tabId ~= self.parent.MainPanel.selectedPage then
         return
     end
 
+    -- refresh items if dirty or pulldownTravel option changed
+    -- pulldownTravel requires hidden quickslots to be added
+    if Settings.pulldownTravel == self.travelOnSelect and not(self.parent.dirty) then
+        return
+    end
+
+    self.travelOnSelect = Settings.pulldownTravel;
     self.pulldown:ClearItems();
 
     -- add the shortcuts to the combo box
-    local shortcutIndex = 1;
     for i = 1, #TravelShortcuts, 1 do
         if TravelShortcuts[i].found and TravelShortcuts[i]:IsEnabled() then
             if (hasbit(Settings.filters, bit(TravelShortcuts[i]:GetTravelType()))) then
-                self.pulldown:AddItem(TravelShortcuts[i], shortcutIndex, i);
-                shortcutIndex = shortcutIndex + 1;
+                self.pulldown:AddItem(TravelShortcuts[i], i);
             end
         end
     end
 
-    if #self.pulldown.quickslots > 0 then
+    if #self.pulldown.labels > 0 then
         self.pulldown:ItemSelected(1);
         self.pulldown:FireEvent();
     else


### PR DESCRIPTION
Besides the bug fixes for the issues mentioned in #173, the pulldown scrollbar's thumb button can be grabbed without closing the dropdown window. However, this fix led to some unexpected API issues. The first triggers a fadeout (a MouseLeave event) when the cursor leaves the scrollbar. The second triggers the FocusLost event, which prevents the dropdown from closing on an arbitrary click. Both of these issues are minor. They are probably fixable with some clever tricks, but nothing I was trying was successful. I figured it was better to have grab & drag scrolling with some minor issues, than to not have it at all. I notated the issue in the code.