### PR TITLE
v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: thedoctor0/zip-release@master
         with:
           filename: 'TravelWindowII-${{ github.event.inputs.tag }}.zip'
-          exclusions: '*.git* *.github* *.vscode* *.gitignore*'
+          exclusions: '*.git* *.github* *.vscode* *.gitignore* data screenshots'
 
       # create the GitHub release
       - name: create github release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## v2.1.0
+- add: default and alphabetic ordering buttons in sorting tab (note: sort by name sorts by ingame name, not by TW II label)
+- add: a fade out delay and option slider to control duration of that delay
+- enhance: mini and legacy windows having the same minimum size
+- enhance: resize hitbox now has highlight on hover
+- enhance: increased size for mini-window resize hitbox
+- enhance: overlapping skills button no longer turns off Lalia's market
+- enhance: enable/disable overlapping skills buttons only show up if character has overlapping skills
+- enhance: updated labels for King's Gondor Dol Amroth in EN/DE/FR
+- enhance: download size of plugin reduced from 2MB+ to 200kb
+- fix: last entry in text list being not visible in legacy window
+- fix: made row snapping much smoother
+- fix: multiple small resizing issues
+
 ## v2.0.0
 - adds a mini window option offering an alternative interface with minimal window size
 - adds skills snapping for cleaner resizing of main and mini windows

--- a/TravelWindowII.plugin
+++ b/TravelWindowII.plugin
@@ -3,7 +3,7 @@
     <Information>
         <Name>Travel Window II</Name>
         <Author>Hyoss</Author>
-        <Version>v2.0.0</Version>
+        <Version>v2.1.0</Version>
         <Description>
         This plugin creates a single window that contains all the available travel skills, including the race, class and reputation skills.
 It is a further development of Travel Window, that has been worked on by multiple authors before.

--- a/TravelWindowII.plugincompendium
+++ b/TravelWindowII.plugincompendium
@@ -2,7 +2,7 @@
 <PluginConfig xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Id>1113</Id>
   <Name>Travel Window II</Name>
-  <Version>v2.0.0</Version>
+  <Version>v2.1.0</Version>
   <Author>Hyoss</Author>
   <InfoUrl>http://www.lotrointerface.com/downloads/info1113</InfoUrl>
   <DownloadUrl>http://www.lotrointerface.com/downloads/download1113</DownloadUrl>

--- a/doc/lotroforums.md
+++ b/doc/lotroforums.md
@@ -1,17 +1,18 @@
 A new version is available!
 
-v2.0.0
-- adds a mini window option offering an alternative interface with minimal window size
-- adds skills snapping for cleaner resizing of main and mini windows
-- adds slider to control speed of fadeout to min opacity
-- adds the ability to save a global preset so main options can be transferred to alts
-- adds option to control whether Esc closes main Travel window
-- adds enable/disable all buttons in enable options tab
-- adds enable/disable button for overlapping class/reputation skills in enable options tab
-- sets default sort so racial & class skills come after general skills to get closer to level progression sorting
-- fixes Travel Window opening behind chat and Travel Button
-- fixes missing Return to Dol Amroth (Western Gondor) in DE client
-- significant code cleanup under the hood for more reliable and maintainable code
+v2.1.0
+- add: default and alphabetic ordering buttons in sorting tab (note: sort by name sorts by ingame name, not by TW II label)
+- add: a fade out delay and option slider to control duration of that delay
+- enhance: mini and legacy windows having the same minimum size
+- enhance: resize hitbox now has highlight on hover
+- enhance: increased size for mini-window resize hitbox
+- enhance: overlapping skills button no longer turns off Lalia's market
+- enhance: enable/disable overlapping skills buttons only show up if character has overlapping skills
+- enhance: updated labels for King's Gondor Dol Amroth in EN/DE/FR
+- enhance: download size of plugin reduced from 2MB+ to 200kb
+- fix: last entry in text list being not visible in legacy window
+- fix: made row snapping much smoother
+- fix: multiple small resizing issues
 
 Huge kudos to @whiterabbit963 for making this release possible!
 

--- a/doc/lotrointerface.md
+++ b/doc/lotrointerface.md
@@ -32,18 +32,19 @@ Use the mousewheel while hovering over the travel skill icon to change the selec
 [/LIST]
 
 Version history:
-v2.0.0
-- adds a mini window option offering an alternative interface with minimal window size
-- adds skills snapping for cleaner resizing of main and mini windows
-- adds slider to control speed of fadeout to min opacity
-- adds the ability to save a global preset so main options can be transferred to alts
-- adds option to control whether Esc closes main Travel window
-- adds enable/disable all buttons in enable options tab
-- adds enable/disable button for overlapping class/reputation skills in enable options tab
-- sets default sort so racial & class skills come after general skills to get closer to level progression sorting
-- fixes Travel Window opening behind chat and Travel Button
-- fixes missing Return to Dol Amroth (Western Gondor) in DE client
-- significant code cleanup under the hood for more reliable and maintainable code
+v2.1.0
+- add: default and alphabetic ordering buttons in sorting tab (note: sort by name sorts by ingame name, not by TW II label)
+- add: a fade out delay and option slider to control duration of that delay
+- enhance: mini and legacy windows having the same minimum size
+- enhance: resize hitbox now has highlight on hover
+- enhance: increased size for mini-window resize hitbox
+- enhance: overlapping skills button no longer turns off Lalia's market
+- enhance: enable/disable overlapping skills buttons only show up if character has overlapping skills
+- enhance: updated labels for King's Gondor Dol Amroth in EN/DE/FR
+- enhance: download size of plugin reduced from 2MB+ to 200kb
+- fix: last entry in text list being not visible in legacy window
+- fix: made row snapping much smoother
+- fix: multiple small resizing issues
 
 Huge kudos to @whiterabbit963 for making this release possible!
 

--- a/src/IndexedDictionaryDe.lua
+++ b/src/IndexedDictionaryDe.lua
@@ -132,7 +132,7 @@ function TravelDictionary:CreateDictionaries()
     self.hunter:AddSkill("Führer nach Carn Dûm", "0x70064AC8", "Carn Dûm (Führer)");
     self.hunter:AddSkill("Führer nach Clegur", "0x70064F4C", "Clegur (Führer)");
     self.hunter:AddSkill("Führer nach Pelargir", "0x700658EA", "Pelargir (Führer)");
-    self.hunter:AddSkill("Führer nach Dol Amroth", "0x70068711", "Königreich Dol Amroth (Führer U38)", "Königreich Gondor");
+    self.hunter:AddSkill("Führer nach Dol Amroth", "0x70068711", "Dol Amroth - Königreich Gondor (Führer)", "Königreich Gondor");
     self.hunter:AddSkill("Führer nach Halrax", "0x70068713", "Halrax (Führer)");
     self.hunter:AddSkill("Führer nach Lond Cirion", "0x70068717", "Lond Cirion (Führer)");
     self.hunter:AddSkill("Führer nach Umbar", "0x70068718", "Umbar (Führer)");
@@ -191,7 +191,7 @@ function TravelDictionary:CreateDictionaries()
     self.warden:AddSkill("Appell in Jax Phanâl","0x7006870C", "Jax Phanâl (Appell)");
     self.warden:AddSkill("Appell in Umbar","0x7006870F","Umbar (Appell)");
     self.warden:AddSkill("Appell in Halrax","0x70068710", "Halrax (Appell)");
-    self.warden:AddSkill("Appell in Dol Amroth","0x70068712", "Königreich Dol Amroth (Appell)", "Königreich Gondor");
+    self.warden:AddSkill("Appell in Dol Amroth","0x70068712", "Dol Amroth - Königreich Gondor (Appell)", "Königreich Gondor");
     self.warden:AddSkill("Appell in Lond Cirion","0x70068715", "Lond Cirion (Appell)");
     self.warden:AddSkill("Appell in der Taverne \"Zum Blutigen Adler\"","0x700697F3", "Zum Blutigen Adler (Appell)");
 
@@ -213,7 +213,7 @@ function TravelDictionary:CreateDictionaries()
     self.mariner:AddSkill("Nach Umbar segeln", "0x700687BB", "Umbar (Segeln)")
     self.mariner:AddSkill("Nach Lond Cirion segeln", "0x700687BD", "Lond Cirion (Segeln)")
     self.mariner:AddSkill("Nach Jax Phanâl segeln", "0x700687C0", "Jax Phanâl (Segeln)")
-    self.mariner:AddSkill("Segelt nach Dol Amroth", "0x700687C1", "Königreich Dol Amroth (Segeln)", "Königreich Gondor")
+    self.mariner:AddSkill("Segelt nach Dol Amroth", "0x700687C1", "Dol Amroth - Königreich Gondor (Segeln)", "Königreich Gondor")
     self.mariner:AddSkill("Nach Halrax segeln", "0x700687C3", "Halrax (Segeln)")
 
     -- add the racial travel skills
@@ -300,7 +300,7 @@ function TravelDictionary:CreateDictionaries()
     self.rep:AddSkill("Rückkehr nach Pelargir", "0x700658EB", "Pelargir (Ruf)");
     self.rep:AddSkill("Zum Orden des Adlers reisen", "0x700686FE", "Orden des Adlers (Ruf)");
     self.rep:AddSkill("Nach Umbar zurückkehren", "0x700686FF", "Umbar (Ruf)");
-    self.rep:AddSkill("Rückkehr nach Dol Amroth", "0x70068700", "Königreich Dol Amroth (Ruf U38)", "Königreich Gondor");
+    self.rep:AddSkill("Rückkehr nach Dol Amroth", "0x70068700", "Dol Amroth - Königreich Gondor (Ruf)", "Königreich Gondor");
     self.rep:AddSkill("Nach Jax Phanâl zurückkehren", "0x70068701", "Jax Phanâl (Ruf)");
     self.rep:AddSkill("Kehrt zu Halrax zurück.", "0x70068702", "Halrax (Ruf)");
     self.rep:AddSkill("Nach Lond Cirion zurückkehren", "0x70068703", "Lond Cirion (Ruf)");

--- a/src/IndexedDictionaryDe.lua
+++ b/src/IndexedDictionaryDe.lua
@@ -39,6 +39,8 @@ maxString = "Max: ";
 resetSettingsString = "Rücksetzen auf Standard";
 saveGlobalDefaultsString = "Globale Standardwerte speichern";
 loadGlobalDefaultsString = "Globale Standardwerte laden";
+defaultSortString = "Auf Standard zurücksetzen";
+sortNameString = "Nach Namen sortieren";
 checkSkillsString = "Nicht erlernte Fertigkeiten prüfen";
 enableRepSkillsString = "Überlappende Aktivieren";
 disableRepSkillsString = "Überlappende Deaktivieren";
@@ -47,6 +49,7 @@ disableAllString = "Alle Deaktivieren";
 ignoreEscString = "Escape schliesst Travel-Fenster nicht";
 minWindowString = "Mini-Fenster verwenden";
 fadeWindowString = "Geschwindigkeit des Fenster-Fadeouts";
+fadeDelayString = "Verzögerung des Fenster-Fadeouts";
 
 -- menu strings
 menuFiltersString = "Filter";

--- a/src/IndexedDictionaryEn.lua
+++ b/src/IndexedDictionaryEn.lua
@@ -132,7 +132,7 @@ function TravelDictionary:CreateDictionaries()
     self.hunter:AddSkill("Guide to Carn Dûm", "0x70064AC8", "Carn Dûm (Guide)");
     self.hunter:AddSkill("Guide to Clegur", "0x70064F4C", "Clegur (Guide)");
     self.hunter:AddSkill("Guide to Pelargir", "0x700658EA", "Pelargir (Guide)");
-    self.hunter:AddSkill("Guide to Dol Amroth", "0x70068711", "King's Dol Amroth (Guide U38)", "King's Gondor");
+    self.hunter:AddSkill("Guide to Dol Amroth", "0x70068711", "King's Dol Amroth (Guide)", "King's Gondor");
     self.hunter:AddSkill("Guide to Halrax", "0x70068713", "Halrax (Guide)");
     self.hunter:AddSkill("Guide to Lond Cirion", "0x70068717", "Lond Cirion (Guide)");
     self.hunter:AddSkill("Guide to Umbar", "0x70068718", "Umbar (Guide)");
@@ -300,7 +300,7 @@ function TravelDictionary:CreateDictionaries()
     self.rep:AddSkill("Return to Pelargir", "0x700658EB", "Pelargir (Rep)");
     self.rep:AddSkill("Journey to the Order of the Eagle", "0x700686FE", "Order of the Eagle (Rep)");
     self.rep:AddSkill("Return to Umbar", "0x700686FF", "Umbar (Rep)");
-    self.rep:AddSkill("Return to Dol Amroth", "0x70068700", "King's Dol Amroth (Rep U38)","King's Gondor");
+    self.rep:AddSkill("Return to Dol Amroth", "0x70068700", "King's Dol Amroth (Rep)","King's Gondor");
     self.rep:AddSkill("Return to Jax Phanâl", "0x70068701", "Jax Phanâl (Rep)");
     self.rep:AddSkill("Return to Halrax", "0x70068702", "Halrax (Rep)");
     self.rep:AddSkill("Return to Lond Cirion", "0x70068703", "Lond Cirion (Rep)");

--- a/src/IndexedDictionaryEn.lua
+++ b/src/IndexedDictionaryEn.lua
@@ -39,6 +39,8 @@ maxString = "Max: ";
 resetSettingsString = "Reset to Defaults";
 saveGlobalDefaultsString = "Save Global Defaults";
 loadGlobalDefaultsString = "Load Global Defaults";
+defaultSortString = "Reset to Default";
+sortNameString = "Sort by Name";
 checkSkillsString = "Check Untrained Skills";
 enableRepSkillsString = "Enable Overlapping";
 disableRepSkillsString = "Disable Overlapping";
@@ -47,6 +49,7 @@ disableAllString = "Disable All";
 ignoreEscString = "Escape does not close main window";
 minWindowString = "Use Mini-Window";
 fadeWindowString = "Fade Window Speed";
+fadeDelayString = "Fade Window Delay";
 
 -- menu strings
 menuFiltersString = "Filters";

--- a/src/IndexedDictionaryFr.lua
+++ b/src/IndexedDictionaryFr.lua
@@ -39,6 +39,8 @@ maxString = "Max: ";
 resetSettingsString = "Remise a zéro";
 saveGlobalDefaultsString = "Enregistrer par défaut globales";
 loadGlobalDefaultsString = "Charger par défaut globales";
+defaultSortString = "Réinitialiser par défaut";
+sortNameString = "Trier par Nom";
 checkSkillsString = "Vérification des compétences non utilisées";
 enableRepSkillsString = "Activer le chevauchement";
 disableRepSkillsString = "Désactiver le chevauchement";
@@ -47,6 +49,7 @@ disableAllString = "Désactiver tout";
 ignoreEscString = "Escape ne pas fermer la fenêtre principale";
 minWindowString = "Utiliser la mini-fenêtre";
 fadeWindowString = "Fondu de la vitesse de la fenêtre";
+fadeDelayString = "Délai de la fenêtre de fondu";
 
 -- menu strings
 menuFiltersString = "Filtres";

--- a/src/IndexedDictionaryFr.lua
+++ b/src/IndexedDictionaryFr.lua
@@ -132,7 +132,7 @@ function TravelDictionary:CreateDictionaries()
     self.hunter:AddSkill("Guide vers Carn Dûm", "0x70064AC8", "Carn Dûm (Guide)");
     self.hunter:AddSkill("Guide vers Clegur", "0x70064F4C", "Clegur (Guide)");
     self.hunter:AddSkill("Guide vers Pelargir", "0x700658EA", "Pelargir (Guide)");
-    self.hunter:AddSkill("Guide vers Dol Amroth", "0x70068711", "Dol Amroth royal (Guide U38)", "le Gondor royal");
+    self.hunter:AddSkill("Guide vers Dol Amroth", "0x70068711", "Dol Amroth - Gondor royal (Guide)", "le Gondor royal");
     self.hunter:AddSkill("Guide vers Halrax", "0x70068713", "Halrax (Guide)");
     self.hunter:AddSkill("Guide vers Lond Cirion", "0x70068717", "Lond Cirion (Guide)");
     self.hunter:AddSkill("Guide vers Umbar", "0x70068718", "Umbar (Guide)");
@@ -191,7 +191,7 @@ function TravelDictionary:CreateDictionaries()
     self.warden:AddSkill("Rassemblement à Jax Phanâl","0x7006870C", "Jax Phanâl (Rassemblement)");
     self.warden:AddSkill("Rassemblement à Umbar","0x7006870F","Umbar (Rassemblement)");
     self.warden:AddSkill("Rassemblement à Halrax","0x70068710", "Halrax (Rassemblement)");
-    self.warden:AddSkill("Rassemblement à Dol Amroth","0x70068712", "Dol Amroth royal (Rassemblement)", "le Gondor royal");
+    self.warden:AddSkill("Rassemblement à Dol Amroth","0x70068712", "Dol Amroth - Gondor royal (Rassemblement)", "le Gondor royal");
     self.warden:AddSkill("Rassemblement à Lond Cirion","0x70068715", "Lond Cirion (Rassemblement)");
     self.warden:AddSkill("Rassemblement à la taverne de l'Aigle sanglant","0x700697F3", "Taverne de l'Aigle sanglant (Rassemblement)");
 
@@ -213,7 +213,7 @@ function TravelDictionary:CreateDictionaries()
     self.mariner:AddSkill("Naviguer vers Umbar", "0x700687BB", "Umbar (Naviguer)");
     self.mariner:AddSkill("Naviguer vers Lond Cirion", "0x700687BD", "Lond Cirion (Naviguer)");
     self.mariner:AddSkill("Naviguer vers Jax Phanâl", "0x700687C0", "Jax Phanâl (Naviguer)");
-    self.mariner:AddSkill("Naviguer vers Dol Amroth", "0x700687C1", "Dol Amroth royal (Naviguer)", "le Gondor royal");
+    self.mariner:AddSkill("Naviguer vers Dol Amroth", "0x700687C1", "Dol Amroth - Gondor royal (Naviguer)", "le Gondor royal");
     self.mariner:AddSkill("Naviguer vers Halrax", "0x700687C3", "Halrax (Naviguer)");
 
     -- add the racial travel skills
@@ -300,7 +300,7 @@ function TravelDictionary:CreateDictionaries()
     self.rep:AddSkill("Retournez à Pelargir", "0x700658EB", "Pelargir (Rep)");
     self.rep:AddSkill("Voyager vers l'Ordre de l'Aigle", "0x700686FE", "L'Ordre de l'Aigle (Rep)");
     self.rep:AddSkill("Retour à Umbar", "0x700686FF", "Umbar (Rep)");
-    self.rep:AddSkill("Retour à Dol Amroth", "0x70068700", "Dol Amroth royal (Rep U38)", "le Gondor royal");
+    self.rep:AddSkill("Retour à Dol Amroth", "0x70068700", "Dol Amroth - Gondor royal (Rep)", "le Gondor royal");
     self.rep:AddSkill("Retour à Jax Phanâl", "0x70068701", "Jax Phanâl (Rep)");
     self.rep:AddSkill("Retournez voir Halrax", "0x70068702", "Halrax (Rep)");
     self.rep:AddSkill("Retour à Lond Cirion", "0x70068703", "Lond Cirion (Rep)");

--- a/src/OptionsPanel.lua
+++ b/src/OptionsPanel.lua
@@ -315,6 +315,25 @@ function OptionsPanel:AddGeneralItems()
     self.mainMaxScrollBar:SetValue(Settings.mainMaxOpacity * 100);
     self.mainMaxScrollBar:SetParent(self.GeneralTab);
 
+    -- fade out delay slider label
+    self.fadeDelaySlidersLabel = Turbine.UI.Label();
+    self.fadeDelaySlidersLabel:SetSize(labelWidth, 20);
+    self.fadeDelaySlidersLabel:SetPosition(20, NextY(25));
+    self.fadeDelaySlidersLabel:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
+    self.fadeDelaySlidersLabel:SetParent(self.GeneralTab);
+    self.fadeDelaySlidersLabel:SetText(fadeDelayString);
+    self.fadeDelaySlidersLabel:SetVisible(true);
+
+    -- fade out delay slider
+    self.fadeDelayScrollBar = Turbine.UI.Lotro.ScrollBar();
+    self.fadeDelayScrollBar:SetOrientation(Turbine.UI.Orientation.Horizontal);
+    self.fadeDelayScrollBar:SetSize(450, 10);
+    self.fadeDelayScrollBar:SetPosition(20, NextY(25));
+    self.fadeDelayScrollBar:SetMinimum(0);
+    self.fadeDelayScrollBar:SetMaximum(100);
+    self.fadeDelayScrollBar:SetValue(Settings.fadeOutDelay);
+    self.fadeDelayScrollBar:SetParent(self.GeneralTab);
+
     -- fade out slider label
     self.mainFadeSlidersLabel = Turbine.UI.Label();
     self.mainFadeSlidersLabel:SetSize(labelWidth, 20);
@@ -499,6 +518,10 @@ function OptionsPanel:AddGeneralItems()
         _G.travel:UpdateSettings();
     end
 
+    self.fadeDelayScrollBar.ValueChanged = function(sender, args)
+        Settings.fadeOutDelay = self.fadeDelayScrollBar:GetValue();
+    end
+
     self.mainFadeScrollBar.ValueChanged = function(sender, args)
         Settings.fadeOutSteps = self.mainFadeScrollBar:GetValue();
         _G.travel:UpdateOpacity();
@@ -519,6 +542,7 @@ function OptionsPanel:UpdateSettings()
     self.mainMinScrollBar:SetValue(Settings.mainMinOpacity * 100);
     self.mainMaxScrollBar:SetValue(Settings.mainMaxOpacity * 100);
     self.mainFadeScrollBar:SetValue(Settings.fadeOutSteps);
+    self.fadeDelayScrollBar:SetValue(Settings.fadeOutDelay);
 end
 
 -- function to add all the travel shortcuts that can be toggled
@@ -720,7 +744,7 @@ end
 
 function OptionsPanel:SetupOverlapLinks()
     if PlayerClass == Turbine.Gameplay.Class.Hunter then
-        self:AddOverlapLinks("0x70003F42", {"0x700062F6", "0x7001BF90", "0x700364B1"}); -- Bree
+        self:AddOverlapLinks("0x70003F42", {"0x700062F6", "0x7001BF90"}); -- Bree
         self:AddOverlapLinks("0x70003F41", {"0x70006346", "0x70053C0F", "0x7001BF91"}); -- Thorin's Hall
         self:AddOverlapLinks("0x7000A2C3", {"0x700062C8", "0x70023262"}); -- Michel Delving
         self:AddOverlapLinks("0x7000A2C2", {"0x70020441"}); -- Ost Guruth
@@ -957,6 +981,36 @@ function OptionsPanel:AddSortButtons()
     self.moveBottomButton:SetText(moveBottomString);
     self.moveBottomButton:SetParent(self.SortTab);
     self.moveBottomButton:SetVisible(true);
+
+    self.defaultSortButton = Turbine.UI.Lotro.Button();
+    self.defaultSortButton:SetSize(185, 20);
+    self.defaultSortButton:SetPosition(10, 375);
+    self.defaultSortButton:SetText(defaultSortString);
+    self.defaultSortButton:SetParent(self.SortTab);
+    self.defaultSortButton:SetVisible(true);
+
+    self.nameSortButton = Turbine.UI.Lotro.Button();
+    self.nameSortButton:SetSize(185, 20);
+    self.nameSortButton:SetPosition(10, 405);
+    self.nameSortButton:SetText(sortNameString);
+    self.nameSortButton:SetParent(self.SortTab);
+    self.nameSortButton:SetVisible(true);
+
+    self.defaultSortButton.Click = function(sender, args)
+        Settings.order = {};
+        CheckEnabledSettings(); -- restore default Settings.order
+        SortFromSettings();
+        self:AddSortList();
+        _G.travel.dirty = true;
+        _G.travel:UpdateSettings();
+    end
+
+    self.nameSortButton.Click = function(sender, args)
+        SortByName();
+        self:AddSortList();
+        _G.travel.dirty = true;
+        _G.travel:UpdateSettings();
+    end
 
     -- handle the move to top button click
     self.moveTopButton.Click = function(sender, args)

--- a/src/SettingsMenu.lua
+++ b/src/SettingsMenu.lua
@@ -222,6 +222,7 @@ function InitDefaultSettings()
     Settings.mainMaxOpacity = 1;
     Settings.mainMinOpacity = 0.5;
     Settings.fadeOutSteps = 1;
+    Settings.fadeOutDelay = 0;
     Settings.toggleMaxOpacity = 1;
     Settings.toggleMinOpacity = 0.5;
 
@@ -332,6 +333,7 @@ function SetSettings(settingsArg, importOldSettings)
     InitNumberSetting(settingsArg, "mainMaxOpacity");
     InitNumberSetting(settingsArg, "mainMinOpacity");
     InitNumberSetting(settingsArg, "fadeOutSteps");
+    InitNumberSetting(settingsArg, "fadeOutDelay");
     InitNumberSetting(settingsArg, "toggleMaxOpacity");
     InitNumberSetting(settingsArg, "toggleMinOpacity");
 
@@ -388,6 +390,7 @@ function SaveSettings(scope)
     settingsStrings.mainMaxOpacity = tostring(Settings.mainMaxOpacity);
     settingsStrings.mainMinOpacity = tostring(Settings.mainMinOpacity);
     settingsStrings.fadeOutSteps = tostring(Settings.fadeOutSteps);
+    settingsStrings.fadeOutDelay = tostring(Settings.fadeOutDelay);
     settingsStrings.toggleMaxOpacity = tostring(Settings.toggleMaxOpacity);
     settingsStrings.toggleMinOpacity = tostring(Settings.toggleMinOpacity);
     settingsStrings.enabled = TableCopy(Settings.enabled);

--- a/src/TravelGridTab.lua
+++ b/src/TravelGridTab.lua
@@ -24,14 +24,11 @@ function TravelGridTab:Constructor(toplevel)
     self.maxScroll = 0;
     self.colWidth = 35;
     self.scrollChunk = self.colWidth;
-    self.minCols = 5;
+    self.minCols = 4;
 
     if self.parent == nil then
         -- need top level window in order to close it
         self.parent = toplevel;
-    end
-    if self.parent.isMinWindow then
-        self.minCols = 4;
     end
 
     -- a subwindow (now a control) for containing all the quickslots
@@ -263,12 +260,8 @@ function TravelGridTab:GetGridDims(width, height)
     if width < self.minCols * self.colWidth then width = self.minCols * self.colWidth end
     if height < self.colWidth then height = self.colWidth end
 
-    local scrollPadding = 0;
-    if not self.parent.isMinWindow then
-        scrollPadding = 10;
-    end
     local numOfShortcuts =  #self.selected;
-    local numOfCols = math.floor((width - scrollPadding) / self.colWidth);
+    local numOfCols = math.floor(width / self.colWidth);
     local numOfRows = math.ceil(numOfShortcuts / numOfCols);
 
     -- set the maximum scroll of the scrollbar
@@ -277,8 +270,7 @@ function TravelGridTab:GetGridDims(width, height)
         maxScroll = 0;
     elseif self.parent.isMinWindow and maxScroll > 0 then
         -- include scrollbar width
-        scrollPadding = 10;
-        numOfCols = math.floor((width - scrollPadding) / self.colWidth);
+        numOfCols = math.floor((width - 10) / self.colWidth);
         numOfRows = math.ceil(numOfShortcuts / numOfCols);
         maxScroll = numOfRows * self.colWidth - height;
     end
@@ -308,6 +300,13 @@ function TravelGridTab:UpdateBounds()
     self.numOfCols = c;
     self.numOfRows = r;
     self.maxScroll = m;
+    if not self.parent.isMinWindow then
+        if c == self.minCols then
+            self.parent:SetText("TW");
+        else
+            self.parent:SetText(mainTitleString);
+        end
+    end
 end
 
 function TravelGridTab:GetMargin(numOfShortcuts)

--- a/src/TravelListTab.lua
+++ b/src/TravelListTab.lua
@@ -62,10 +62,13 @@ function TravelListTab:AddItem(shortcut)
 
     -- set the index value based on the row and column
     local index = (self.row - 1) + self.col;
-
+    local x = 10 + ((self.col - 1) * (self.itemWidth + 2));
+    local y = (self.row - 1) * self.itemHeight - self.myScrollBar:GetValue();
     if not(self.parent.dirty) then
         self.quickslots[index]:SetSize(self.itemWidth, self.itemHeight);
         self.labels[index]:SetSize(self.itemWidth, self.itemHeight);
+        self.quickslots[index]:SetPosition(x, y);
+        self.labels[index]:SetPosition(x, y);
     else
         if index == 1 then
             self.labels = {};
@@ -74,8 +77,7 @@ function TravelListTab:AddItem(shortcut)
         -- based on the row and column locations
         self.quickslots[index] = Turbine.UI.Lotro.Quickslot();
         self.quickslots[index]:SetSize(self.itemWidth, self.itemHeight);
-        self.quickslots[index]:SetPosition(10 + ((self.col - 1) * (self.itemWidth + 2)),
-                                           (self.row - 1) * self.itemHeight);
+        self.quickslots[index]:SetPosition(x, y);
         self.quickslots[index]:SetZOrder(90);
         self.quickslots[index]:SetOpacity(1);
         self.quickslots[index]:SetUseOnRightClick(false);
@@ -88,8 +90,7 @@ function TravelListTab:AddItem(shortcut)
         -- create the label that will cover the shortcut
         self.labels[index] = Turbine.UI.Label();
         self.labels[index]:SetSize(self.itemWidth, self.itemHeight);
-        self.labels[index]:SetPosition(10 + ((self.col - 1) * (self.itemWidth + 2)),
-                                       (self.row - 1) * self.itemHeight);
+        self.labels[index]:SetPosition(x, y);
         self.labels[index]:SetZOrder(100);
         self.labels[index]:SetMouseVisible(false);
         self.labels[index]:SetTextAlignment(Turbine.UI.ContentAlignment.MiddleLeft);
@@ -140,8 +141,8 @@ end
 
 function TravelListTab:FitToPixels(width, height)
     local rowHeight = self.itemHeight;
-    local minHeight = self.parent.hPadding + rowHeight * 6;
-    local maxHeight = self.parent.hPadding + rowHeight * #self.selected;
+    local minHeight = rowHeight * 6;
+    local maxHeight = rowHeight * #self.selected;
     height = height - self.parent.hPadding;
     local dy = height % rowHeight;
     if dy < rowHeight / 2 then
@@ -156,20 +157,21 @@ function TravelListTab:FitToPixels(width, height)
     end
     self.pixelWidth = width;
     self.numOfRows = math.floor(height / rowHeight);
-    return width, height;
+    return width, height + self.parent.hPadding;
 end
 
 function TravelListTab:UpdateBounds()
     -- set the maximum value of the scrollbar
     -- based on the number of rows in the subwindow
     local numOfShortcuts = #self.selected;
-    self.maxScroll = numOfShortcuts * self.itemHeight - self.parent:GetHeight();
+    local height = self.parent:GetHeight() - self.parent.hPadding;
+    self.maxScroll = numOfShortcuts * self.itemHeight - height;
     if self.maxScroll < 0 then
         -- the maxScroll cannot be less than one
         self.maxScroll = 0;
         self.numOfRows = #self.selected;
     elseif self.maxScroll > 0 then
-        self.numOfRows = math.floor(self.parent:GetHeight() / self.itemHeight);
+        self.numOfRows = math.floor(height / self.itemHeight);
     end
     self.pixelWidth = self.parent:GetWidth();
 end

--- a/src/TravelShortcut.lua
+++ b/src/TravelShortcut.lua
@@ -9,6 +9,7 @@ function TravelShortcut:Constructor(sType, tType, data, name, skillLabel, desc)
     -- the data to keep track of
     self.Name = name;
     self.desc = desc;
+    self.normalizedName = name:lower();
     self.travelType = tType;
     self.Index = TableIndex(Settings.order, data);
     self.Enabled = Settings.enabled[data];
@@ -133,6 +134,23 @@ function AddTravelSkills(skills, filter)
     end
 end
 
+function SortByName()
+    local comp = function(a, b)
+        if a.normalizedName > b.normalizedName then
+            return true;
+        elseif a.normalizedName == b.normalizedName then
+            return a:GetData() > b:GetData();
+        else
+            return false;
+        end
+    end
+    SortShortcuts(comp);
+    Settings.order = {};
+    for i = 1, #TravelShortcuts do
+        table.insert(Settings.order, TravelShortcuts[i]:GetData());
+    end
+end
+
 function SortFromSettings()
     for i = 1, #TravelShortcuts do
         local id = TravelShortcuts[i]:GetData();
@@ -141,14 +159,20 @@ function SortFromSettings()
     SortShortcuts();
 end
 
--- TravelShortcuts are sorted by an internal index value
-function SortShortcuts()
+function SortShortcuts(comp)
+    if comp == nil then
+        -- By default TravelShortcuts are sorted by an internal index value
+        comp = function(a, b)
+            return a:GetIndex() > b:GetIndex();
+        end
+    end
+
     -- perform an optimized bubble sort
     local n = #TravelShortcuts;
     while n > 2 do
         local new_n = 1;
         for i = 2, n do
-            if TravelShortcuts[i - 1]:GetIndex() > TravelShortcuts[i]:GetIndex() then
+            if comp(TravelShortcuts[i - 1], TravelShortcuts[i]) then
                 local temp = TravelShortcuts[i - 1];
                 TravelShortcuts[i - 1] = TravelShortcuts[i];
                 TravelShortcuts[i] = temp;

--- a/src/TravelWindow.lua
+++ b/src/TravelWindow.lua
@@ -34,7 +34,7 @@ function TravelWindow:Constructor(useMinWindow)
         self.hPos = 20;
         self.wPadding = -1;
         self.hPadding = 20;
-        self.resizeLabelSize = 13;
+        self.resizeLabelSize = 15;
         self.backColor = Turbine.UI.Color(1, 0, 0, 0);
     else
         self.wPos = 15;
@@ -197,13 +197,32 @@ function TravelWindow:Constructor(useMinWindow)
 
     self.Update = function(sender, args)
         -- handle opacity fade out
-        local stepSize = (Settings.mainMaxOpacity - Settings.mainMinOpacity) / Settings.fadeOutSteps;
-        local opacity = self:GetOpacity() - stepSize;
-        if opacity < Settings.mainMinOpacity then
-            opacity = Settings.mainMinOpacity
-            self:SetWantsUpdates(false);
+        if self.fadeOutDelay == nil then
+            self.fadeOutDelay = Settings.fadeOutDelay;
         end
-        self:SetOpacity(opacity);
+
+        if self.fadeOutDelay > 0 then
+            local now = Turbine.Engine.GetGameTime();
+            if self.fadeDelayStart == nil then
+                self.fadeDelayStart = now + 0.05 * Settings.fadeOutDelay;
+            else
+                if now > self.fadeDelayStart then
+                    self.fadeOutDelay = 0;
+                    self.fadeDelayStart = nil;
+                end
+            end
+        end
+
+        if self.fadeOutDelay == 0 then
+            local stepSize = (Settings.mainMaxOpacity - Settings.mainMinOpacity) / Settings.fadeOutSteps;
+            local opacity = self:GetOpacity() - stepSize;
+            if opacity < Settings.mainMinOpacity then
+                opacity = Settings.mainMinOpacity
+                self:SetWantsUpdates(false);
+                self.fadeOutDelay = nil;
+            end
+            self:SetOpacity(opacity);
+        end
     end
 
     -- if the visible status of the window changes, close the pulldown tab
@@ -226,6 +245,8 @@ function TravelWindow:Constructor(useMinWindow)
     -- go to full opacity if mouse is over
     self.MouseEnter = function(sender, args)
         self:SetMaxOpacity();
+        self.fadeDelayStart = nil;
+        self.fadeOutDelay = nil;
     end
 
     -- go to low opacity when mouse is not over
@@ -295,6 +316,13 @@ function TravelWindow:Constructor(useMinWindow)
     self.resizeLabel.MouseMove = self.MouseMove;
     self.resizeLabel.MouseUp = self.MouseUp;
     self.resizeLabel.MouseClick = self.MouseClick;
+    self.resizeLabel:SetBackColorBlendMode(Turbine.UI.BlendMode.Overlay)
+    self.resizeLabel.MouseEnter = function(sender, args)
+        self.resizeLabel:SetBackColor(Turbine.UI.Color(0.75, 0.4, 0.4, 0.4));
+    end
+    self.resizeLabel.MouseLeave = function(sender, args)
+        self.resizeLabel:SetBackColor(Turbine.UI.Color(0, 0, 0, 0));
+    end
 
     self.SizeChanged = function(sender, args)
         if Settings.mode == 1 then


### PR DESCRIPTION
* add a fade out delay

* add default and alphabetic ordering buttons

* remove lalia's market from the overlapped skills list

* make mini and legacy windows have the same minimum size

* fix #183 and a few other resizing issues

* increase mini-window resize hitbox by a couple pixels

* fix row snapping issue

* add color to the resize hitbox on hover