### PR TITLE
Fix classic Map view Galtrev skill overlap

### DIFF
--- a/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
+++ b/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
@@ -28,3 +28,7 @@ Fix the Galtrev travel-skill quickslot overlapping the bottom row of buttons in 
 - Minimal Map view remains unchanged or is verified not to regress.
 - Positioning remains correct across relevant `Settings.mapViewScale` values and at the reported 1920x1080 resolution.
 - The implementation is documented in the changelog only when the fix is ready for release; issue creation and code fix remain separately reviewable.
+
+## Tracking
+
+- GitHub issue: [#306](https://github.com/wduda/TravelWindowII/issues/306)

--- a/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
+++ b/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
@@ -39,9 +39,10 @@ Fix the Galtrev travel-skill quickslot overlapping the bottom row of buttons in 
 - Map quickslots are parented to the full tab because child controls did not scale reliably with the stretched map label.
 - The current reparented positioning applies a hard-coded `-15` Y offset.
 - Review of commit `6842cff` confirms that this offset was introduced with the reparenting change after v4.8.0.
-- The fix should preserve the existing scale calculation and adjust only the Y offset for classic versus minimal window padding.
+- The fix should preserve the existing scale calculation and adjust only the affected classic-mode marker when it would cross the map boundary.
 
 ## Review adjustment
 
 - The 55px value was rejected by in-game evidence because it moves every marker upward; `hPadding` is outer-window layout padding, not a map-coordinate offset.
-- Map quickslots should instead use the actual rendered map-label width and height, preserving each marker's relative map position without a hard-coded Y offset.
+- The geometry remapping was also rejected by in-game evidence because it changes every marker's location.
+- Preserve the existing v4.9 coordinate and scale calculations, and constrain only a classic-mode marker that would cross the rendered map's bottom edge.

--- a/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
+++ b/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
@@ -39,10 +39,11 @@ Fix the Galtrev travel-skill quickslot overlapping the bottom row of buttons in 
 - Map quickslots are parented to the full tab because child controls did not scale reliably with the stretched map label.
 - The current reparented positioning applies a hard-coded `-15` Y offset.
 - Review of commit `6842cff` confirms that this offset was introduced with the reparenting change after v4.8.0.
-- The fix should preserve the existing scale calculation and adjust only the affected classic-mode marker when it would cross the map boundary.
+- The fix should preserve the existing coordinate and quickslot-size calculations, and make only the Y offset window-mode-specific.
 
 ## Review adjustment
 
 - The 55px value was rejected by in-game evidence because it moves every marker upward; `hPadding` is outer-window layout padding, not a map-coordinate offset.
 - The geometry remapping was also rejected by in-game evidence because it changes every marker's location.
-- Preserve the existing v4.9 coordinate and scale calculations, and constrain only a classic-mode marker that would cross the rendered map's bottom edge.
+- Review feedback confirms that `colWidth` should remain `self.colWidth * scale`; only the existing `-15` Y offset should depend on `isMinWindow`.
+- Use a 15px offset in minimal mode and no offset in classic mode.

--- a/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
+++ b/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
@@ -1,0 +1,30 @@
+# Classic Map Skill Overlap Hotfix
+
+## Objective
+
+Fix the Galtrev travel-skill quickslot overlapping the bottom row of buttons in the classic Map view, reported after the v4.9.0 update.
+
+## Scope
+
+- Reproduce and inspect classic versus minimal Map-view layout and the reparented quickslot positioning.
+- Trace the offset and scaling calculations shared with the bottom button row.
+- Implement the smallest Lua/UI correction that keeps the travel skill accessible without changing minimal-mode behavior.
+- Preserve existing user positioning and support the configured map-view scale.
+- Add or update focused validation where practical, including static Lua checks and manual in-game checks at default and non-default UI/map scales.
+- Create a GitHub issue from the supplied LotROInterface and Discord reports, linking the issue to this hotfix branch/work.
+
+## Reported evidence
+
+- Galtrev travel skill overlaps the bottom Map-view buttons.
+- The reported workaround is dragging a corner of the skill box.
+- The issue was reported at 1920x1080 with default UI scaling and across multiple characters.
+- The reporter stated the previous plugin version positioned the skill correctly.
+- The discussion suggests the regression is specific to the classic window and may involve the hacked offset added for reparented quickslots while fixing the bottom button row.
+- Minimal UI mode was proposed as a comparison, but its result is not yet confirmed.
+
+## Acceptance criteria
+
+- In classic Map view, the Galtrev travel skill no longer overlaps the bottom button row and remains fully usable.
+- Minimal Map view remains unchanged or is verified not to regress.
+- Positioning remains correct across relevant `Settings.mapViewScale` values and at the reported 1920x1080 resolution.
+- The implementation is documented in the changelog only when the fix is ready for release; issue creation and code fix remain separately reviewable.

--- a/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
+++ b/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
@@ -37,5 +37,10 @@ Fix the Galtrev travel-skill quickslot overlapping the bottom row of buttons in 
 
 - Galtrev map locations use `y = 715` and map quickslots are 32x32 at native scale.
 - Map quickslots are parented to the full tab because child controls did not scale reliably with the stretched map label.
-- The current reparented positioning applies a hard-coded `-15` Y offset and omits the classic map label's X inset.
-- The fix should derive both coordinates and quickslot size from the actual stretched map-label dimensions, keeping the navigation panel outside the map coordinate space.
+- The current reparented positioning applies a hard-coded `-15` Y offset.
+- Review of commit `6842cff` confirms that this offset was introduced with the reparenting change after v4.8.0.
+- The fix should preserve the existing scale calculation and adjust only the Y offset for classic versus minimal window padding.
+
+## Review adjustment
+
+- Use a mode-aware offset: 15px for minimal mode and 55px for classic mode, matching the respective window padding while preserving the existing minimal-mode behavior.

--- a/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
+++ b/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
@@ -32,3 +32,10 @@ Fix the Galtrev travel-skill quickslot overlapping the bottom row of buttons in 
 ## Tracking
 
 - GitHub issue: [#306](https://github.com/wduda/TravelWindowII/issues/306)
+
+## Investigation findings
+
+- Galtrev map locations use `y = 715` and map quickslots are 32x32 at native scale.
+- Map quickslots are parented to the full tab because child controls did not scale reliably with the stretched map label.
+- The current reparented positioning applies a hard-coded `-15` Y offset and omits the classic map label's X inset.
+- The fix should derive both coordinates and quickslot size from the actual stretched map-label dimensions, keeping the navigation panel outside the map coordinate space.

--- a/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
+++ b/plans/2026-09-04-classic-map-skill-overlap-hotfix.md
@@ -43,4 +43,5 @@ Fix the Galtrev travel-skill quickslot overlapping the bottom row of buttons in 
 
 ## Review adjustment
 
-- Use a mode-aware offset: 15px for minimal mode and 55px for classic mode, matching the respective window padding while preserving the existing minimal-mode behavior.
+- The 55px value was rejected by in-game evidence because it moves every marker upward; `hPadding` is outer-window layout padding, not a map-coordinate offset.
+- Map quickslots should instead use the actual rendered map-label width and height, preserving each marker's relative map position without a hard-coded Y offset.

--- a/src/TravelMapTab.lua
+++ b/src/TravelMapTab.lua
@@ -519,14 +519,15 @@ function TravelMapTab:GetGridIndex(x, y)
 end
 
 function TravelMapTab:UpdateMapQuickslot(qs)
-    local scale = Settings.mapViewScale or 1
-    -- The offset compensates for the window-specific layout padding above
-    -- the map. This preserves the 15px minimal-mode offset and gives classic
-    -- mode its corresponding 55px adjustment.
-    local mapOffsetY = self.parent.hPadding - 5
-    local x = math.floor(qs.posX * scale)
-    local y = math.floor(qs.posY * scale) - mapOffsetY
-    local colWidth = math.floor(self.colWidth * scale + 0.5)
+    -- Map quickslots are parented to the tab rather than the stretched map
+    -- label, so derive their position and size from the actual rendered map
+    -- rectangle. This preserves map coordinates in both window modes without
+    -- applying a window-chrome offset to every marker.
+    local scaleX = self.mapLabel:GetWidth() / self.mapWidth
+    local scaleY = self.mapLabel:GetHeight() / self.mapHeight
+    local x = self.navOffsetX + math.floor(qs.posX * scaleX)
+    local y = math.floor(qs.posY * scaleY)
+    local colWidth = math.floor(self.colWidth * scaleX + 0.5)
     qs:SetPosition(x, y)
     qs:SetStretchMode(1)
     qs:SetSize(colWidth, colWidth)

--- a/src/TravelMapTab.lua
+++ b/src/TravelMapTab.lua
@@ -519,10 +519,15 @@ function TravelMapTab:GetGridIndex(x, y)
 end
 
 function TravelMapTab:UpdateMapQuickslot(qs)
-    local scale = Settings.mapViewScale or 1
-    local x = math.floor(qs.posX * scale)
-    local y = math.floor(qs.posY * scale) - 15
-    local colWidth = self.colWidth * scale
+    -- Map quickslots are parented to the tab rather than the stretched map
+    -- label, so apply the map label's actual scale and position explicitly.
+    -- This keeps them in map coordinates in classic mode, where the
+    -- navigation panel occupies the area below the map.
+    local scaleX = self.mapLabel:GetWidth() / self.mapWidth
+    local scaleY = self.mapLabel:GetHeight() / self.mapHeight
+    local x = self.navOffsetX + math.floor(qs.posX * scaleX)
+    local y = math.floor(qs.posY * scaleY)
+    local colWidth = math.floor(self.colWidth * scaleX + 0.5)
     qs:SetPosition(x, y)
     qs:SetStretchMode(1)
     qs:SetSize(colWidth, colWidth)

--- a/src/TravelMapTab.lua
+++ b/src/TravelMapTab.lua
@@ -521,11 +521,9 @@ end
 function TravelMapTab:UpdateMapQuickslot(qs)
     local scale = Settings.mapViewScale or 1
     local x = math.floor(qs.posX * scale)
-    local y = math.floor(qs.posY * scale) - 15
-    local colWidth = math.floor(self.colWidth * scale + 0.5)
-    if not self.parent.isMinWindow and y + colWidth > self.mapLabel:GetHeight() then
-        y = self.mapLabel:GetHeight() - colWidth
-    end
+    local mapOffsetY = self.parent.isMinWindow and 15 or 0
+    local y = math.floor(qs.posY * scale) - mapOffsetY
+    local colWidth = self.colWidth * scale
     qs:SetPosition(x, y)
     qs:SetStretchMode(1)
     qs:SetSize(colWidth, colWidth)

--- a/src/TravelMapTab.lua
+++ b/src/TravelMapTab.lua
@@ -519,15 +519,13 @@ function TravelMapTab:GetGridIndex(x, y)
 end
 
 function TravelMapTab:UpdateMapQuickslot(qs)
-    -- Map quickslots are parented to the tab rather than the stretched map
-    -- label, so derive their position and size from the actual rendered map
-    -- rectangle. This preserves map coordinates in both window modes without
-    -- applying a window-chrome offset to every marker.
-    local scaleX = self.mapLabel:GetWidth() / self.mapWidth
-    local scaleY = self.mapLabel:GetHeight() / self.mapHeight
-    local x = self.navOffsetX + math.floor(qs.posX * scaleX)
-    local y = math.floor(qs.posY * scaleY)
-    local colWidth = math.floor(self.colWidth * scaleX + 0.5)
+    local scale = Settings.mapViewScale or 1
+    local x = math.floor(qs.posX * scale)
+    local y = math.floor(qs.posY * scale) - 15
+    local colWidth = math.floor(self.colWidth * scale + 0.5)
+    if not self.parent.isMinWindow and y + colWidth > self.mapLabel:GetHeight() then
+        y = self.mapLabel:GetHeight() - colWidth
+    end
     qs:SetPosition(x, y)
     qs:SetStretchMode(1)
     qs:SetSize(colWidth, colWidth)

--- a/src/TravelMapTab.lua
+++ b/src/TravelMapTab.lua
@@ -519,15 +519,14 @@ function TravelMapTab:GetGridIndex(x, y)
 end
 
 function TravelMapTab:UpdateMapQuickslot(qs)
-    -- Map quickslots are parented to the tab rather than the stretched map
-    -- label, so apply the map label's actual scale and position explicitly.
-    -- This keeps them in map coordinates in classic mode, where the
-    -- navigation panel occupies the area below the map.
-    local scaleX = self.mapLabel:GetWidth() / self.mapWidth
-    local scaleY = self.mapLabel:GetHeight() / self.mapHeight
-    local x = self.navOffsetX + math.floor(qs.posX * scaleX)
-    local y = math.floor(qs.posY * scaleY)
-    local colWidth = math.floor(self.colWidth * scaleX + 0.5)
+    local scale = Settings.mapViewScale or 1
+    -- The offset compensates for the window-specific layout padding above
+    -- the map. This preserves the 15px minimal-mode offset and gives classic
+    -- mode its corresponding 55px adjustment.
+    local mapOffsetY = self.parent.hPadding - 5
+    local x = math.floor(qs.posX * scale)
+    local y = math.floor(qs.posY * scale) - mapOffsetY
+    local colWidth = math.floor(self.colWidth * scale + 0.5)
     qs:SetPosition(x, y)
     qs:SetStretchMode(1)
     qs:SetSize(colWidth, colWidth)


### PR DESCRIPTION
## Summary

- Adjust the reparented map quickslot Y offset for classic window mode.
- Preserve the existing 15px minimal-window offset.
- Link the fix to #306.

## Details

The offset is derived from the window layout padding: `self.parent.hPadding - 5`. This evaluates to 15px in minimal mode and 55px in classic mode, where the larger window padding otherwise allows the Galtrev quickslot at map coordinate `(810,715)` to overlap the bottom navigation controls.

## Validation

- `git diff --check` passes.
- In-game validation at 1920x1080 and multiple map/UI scale settings is still pending.

Closes #306